### PR TITLE
on search use query string without quoted comma's

### DIFF
--- a/plugin.video.viewx/resources/lib/itvx.py
+++ b/plugin.video.viewx/resources/lib/itvx.py
@@ -11,6 +11,7 @@ import logging
 
 from datetime import datetime
 import pytz
+import requests
 import xbmc
 
 from codequick.support import logger_id
@@ -297,11 +298,29 @@ def search(search_term, hide_paid=False):
     url = 'https://textsearch.prd.oasvc.itv.com/search?broadcaster=itv&featureSet=clearkey,outband-webvtt,hls,aes,' \
           'playready,widevine,fairplay,bbts,progressive,hd,rtmpe&onlyFree=false&platform=dotcom&query=' + quote(
         search_term)
-    data = fetch.get_json(url, headers={'Cache-Control': None, 'Pragma': None})
+    headers = {
+        'User-Agent': fetch.USER_AGENT,
+        'accept': 'application/json',
+        'Origin': 'https://www.itv.com',
+        'Referer': 'https://www.itv.com/',
+        'accept-language': 'en-GB,en;q=0.5',
+        'Sec-Fetch-Dest': 'empty',
+        'Sec-Fetch-Mode': 'cors',
+        'Sec-Fetch-Site': 'same-site',
+    }
+    resp = requests.get(url, headers=headers, timeout=fetch.WEB_TIMEOUT)
 
-    if data is None:
-        logger.debug("Search for '%s' returned no data. (hide_paid=%s)", search_term, hide_paid)
-        return
+    if resp.status_code != 200:
+        logger.debug("Search for '%s' (hide_paid=%s) failed with HTTP status %s",
+                     search_term, hide_paid, resp.status_code)
+        return None
+
+    try:
+        data = resp.json()
+    except:
+        logger.warning("Search for '%s' (hide_paid=%s) returned non-json content: '%s'",
+                       search_term, hide_paid, resp.content)
+        return None
 
     results = data.get('results')
     if not results:

--- a/test/local/test_itvx.py
+++ b/test/local/test_itvx.py
@@ -15,7 +15,7 @@ import types
 import time
 import pytz
 
-from test.support.testutils import open_json, open_doc
+from test.support.testutils import open_json, open_doc, HttpResponse
 from test.support.object_checks import has_keys, is_li_compatible_dict, is_url
 
 from resources.lib import itvx, errors
@@ -158,13 +158,13 @@ class Episodes(TestCase):
 
 
 class Search(TestCase):
-    @patch('resources.lib.fetch.get_json', return_value=open_json('search/the_chase.json'))
+    @patch('requests.sessions.Session.send', return_value=HttpResponse(text=open_doc('search/the_chase.json')()))
     def test_simple_search(self, _):
         result = itvx.search('the_chase')
         self.assertIsInstance(result, types.GeneratorType)
         self.assertEqual(10, len(list(result)))
 
-    @patch('resources.lib.fetch.get_json', return_value=None)
+    @patch('requests.sessions.Session.send', return_value=HttpResponse(204))
     def test_search_without_results(self, _):
         result = itvx.search('xprs')
         self.assertIsNone(result)


### PR DESCRIPTION
An attempt to fix the rather hard to test issue of search sometimes not returning results on a search term that normally does have results.