### PR TITLE
correctly save session data

### DIFF
--- a/plugin.video.viwx/resources/lib/itv_account.py
+++ b/plugin.video.viwx/resources/lib/itv_account.py
@@ -64,19 +64,22 @@ class ItvSession:
                 acc_data = json.load(f)
         except (OSError, IOError, ValueError) as err:
             logger.error("Failed to read account data: %r" % err)
-            acc_data = {}
+            self.account_data = {}
+            return
+
+        if acc_data.get('vers') != SESS_DATA_VERS:
+            logger.info("Converting account data from version '%s' to version '%s'",
+                        acc_data.get('vers'), SESS_DATA_VERS)
+            self.account_data = convert_session_data(acc_data)
+            self.save_account_data()
         else:
-            if acc_data.get('vers') != SESS_DATA_VERS:
-                logger.info("Converting account data from version '%s' to version '%s'",
-                            acc_data.get('vers'), SESS_DATA_VERS)
-                acc_data = convert_session_data(acc_data)
-                self.save_account_data()
-        self.account_data = acc_data
+            self.account_data = acc_data
 
     def save_account_data(self):
         session_file = os.path.join(utils.addon_info.profile, "itv_session")
+        data_str = json.dumps(self.account_data)
         with open(session_file, 'w') as f:
-            json.dump(self.account_data, f)
+            f.write(data_str)
         logger.info("ITV account data saved to file")
 
     def login(self, uname: str, passw: str):
@@ -107,6 +110,7 @@ class ItvSession:
             )
 
             self.account_data = {
+                'vers': SESS_DATA_VERS,
                 'refreshed': time.time(),
                 'itv_session': session_data,
                 'cookies': {'Itv.Session': build_cookie(session_data)}

--- a/plugin.video.viwx/resources/lib/itv_account.py
+++ b/plugin.video.viwx/resources/lib/itv_account.py
@@ -19,7 +19,7 @@ from .errors import *
 
 
 logger = logging.getLogger(logger_id + '.account')
-SESS_DATA_VERS = 1
+SESS_DATA_VERS = 2
 
 
 class ItvSession:
@@ -222,4 +222,5 @@ def convert_session_data(acc_data: dict) -> dict:
     sess_data = acc_data.get('itv_session', '')
     acc_data['cookies'] = {'Itv.Session': build_cookie(sess_data)}
     acc_data.pop('passw', None)
+    acc_data.pop('uname', None)
     return acc_data

--- a/test/local/test_account.py
+++ b/test/local/test_account.py
@@ -34,13 +34,13 @@ account_data_v0 = {'uname': 'my_uname', 'passw': 'my_passw',
                    'cookies': {'Itv.Cid': 'xxxxxxxxxxxx'}
                    }
 
-account_data_v1 = {'uname': 'my_uname',
+account_data_v2 = {
                    'refreshed': account_data_v0['refreshed'],
                    'itv_session': {'access_token': 'my-token',
                                    'refresh_token': 'my-refresh-token'},
                    'cookies': {'Itv.Session': '{"sticky": true, "tokens": {"content": {"access_token": "my-token", '
                                               '"refresh_token": "my-refresh-token"}}}'},
-                   'vers': 1
+                   'vers': 2
                    }
 
 
@@ -162,8 +162,8 @@ class PropAccessToken(unittest.TestCase):
     @patch('resources.lib.itv_account.ItvSession.refresh')
     def test_prop_access_token(self, p_refresh, p_login):
         ct_sess = itv_account.ItvSession()
-        ct_sess.account_data = account_data_v1
-        self.assertEqual(account_data_v1['itv_session']['access_token'], ct_sess.access_token)
+        ct_sess.account_data = account_data_v2
+        self.assertEqual(account_data_v2['itv_session']['access_token'], ct_sess.access_token)
         p_refresh.assert_not_called()
         p_login.assert_not_called()
 
@@ -181,7 +181,7 @@ class PropAccessToken(unittest.TestCase):
     @patch('resources.lib.itv_account.ItvSession.refresh', return_value=True)
     def test_prop_access_token_with_cache_timed_out_invokes_refresh(self, p_refresh, p_login):
         ct_sess = itv_account.ItvSession()
-        ct_sess.account_data = deepcopy(account_data_v1)
+        ct_sess.account_data = deepcopy(account_data_v2)
         ct_sess.account_data['refreshed'] = time.time() - 13 * 3600     # force a timeout
         _ = ct_sess.access_token
         p_login.assert_not_called()
@@ -193,8 +193,8 @@ class PropCookie(unittest.TestCase):
     @patch('resources.lib.itv_account.ItvSession.refresh')
     def test_prop_cookie(self, p_refresh, p_login):
         ct_sess = itv_account.ItvSession()
-        ct_sess.account_data = account_data_v1
-        self.assertEqual(account_data_v1['cookies'], ct_sess.cookie)
+        ct_sess.account_data = account_data_v2
+        self.assertEqual(account_data_v2['cookies'], ct_sess.cookie)
         p_refresh.assert_not_called()
         p_login.assert_not_called()
 
@@ -212,7 +212,7 @@ class PropCookie(unittest.TestCase):
     @patch('resources.lib.itv_account.ItvSession.refresh', return_value=True)
     def test_prop_cookie_with_cache_timed_out_invokes_refresh(self, p_refresh, p_login):
         ct_sess = itv_account.ItvSession()
-        ct_sess.account_data = deepcopy(account_data_v1)
+        ct_sess.account_data = deepcopy(account_data_v2)
         ct_sess.account_data['refreshed'] = time.time() - 13 * 3600     # force a timeout
         _ = ct_sess.cookie
         p_login.assert_not_called()
@@ -221,15 +221,15 @@ class PropCookie(unittest.TestCase):
 
 class Misc(unittest.TestCase):
     def test_read_account_data(self):
-        with patch('resources.lib.itv_account.open', mock_open(read_data=json.dumps(account_data_v1))):
+        with patch('resources.lib.itv_account.open', mock_open(read_data=json.dumps(account_data_v2))):
             # test data is being read at class instantiation
             ct_sess = itv_account.ItvSession()
             has_keys(ct_sess.account_data, 'itv_session', 'cookies', 'refreshed', 'vers')
-            self.assertEqual(account_data_v1, ct_sess.account_data)
+            self.assertEqual(account_data_v2, ct_sess.account_data)
             ct_sess.account_data = None
             # test manual read
             ct_sess.read_account_data()
-            self.assertEqual(account_data_v1, ct_sess.account_data)
+            self.assertEqual(account_data_v2, ct_sess.account_data)
         # Account data file not presents
         with patch('resources.lib.itv_account.open', side_effect=OSError):
             ct_sess.read_account_data()
@@ -249,7 +249,7 @@ class Misc(unittest.TestCase):
         with patch('resources.lib.itv_account.open', mock_open(read_data=json.dumps(account_data_v0))):
             ct_sess = itv_account.ItvSession()
             has_keys(ct_sess.account_data, 'itv_session', 'cookies', 'refreshed', 'vers')
-            self.assertEqual(account_data_v1, ct_sess.account_data)
+            self.assertEqual(account_data_v2, ct_sess.account_data)
 
     def test_save_account_data(self):
         ct_sess = itv_account.ItvSession()


### PR DESCRIPTION
Fixes #28
- Save in the correct format after successfull login.
- Save the converted data after file version conversion.
- delete existing username in converison