### PR TITLE
Adapt to new structure of news collection and catagory

### DIFF
--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -137,6 +137,7 @@ def get_live_channels(local_tz=None):
 
 def main_page_items():
     main_data = get_page_data('https://www.itv.com', cache_time=None)
+
     hero_content = main_data.get('heroContent')
     if hero_content:
         for hero_data in hero_content:
@@ -144,14 +145,19 @@ def main_page_items():
             if hero_item:
                 yield hero_item
     else:
-        logger.info("No heroContent in main page.")
+        logger.info("Main page has no heroContent.")
 
     if 'trendingSliderContent' in main_data.keys():
         yield {'type': 'collection',
                'show': {'label': 'Trending', 'params': {'slider': 'trendingSliderContent'}}}
-    if 'newsShortformSliderContent' in main_data.keys():
+    else:
+        logger.info("Main page has no 'Trending' slider.")
+
+    if 'shortFormSliderContent' in main_data.keys():
         yield {'type': 'collection',
-               'show': {'label': 'News', 'params': {'slider': 'newsShortformSliderContent'}}}
+               'show': {'label': 'News', 'params': {'slider': 'shortFormSliderContent'}}}
+    else:
+        logger.info("Main page has no 'News' slider.")
 
 
 def collection_content(url=None, slider=None, hide_paid=False):
@@ -167,10 +173,10 @@ def collection_content(url=None, slider=None, hide_paid=False):
         # A Collection that has all it's data on the main page and does not have its own page.
         page_data = get_page_data('https://www.itv.com', cache_time=3600)
 
-        if slider == 'newsShortformSliderContent':
+        if slider == 'shortFormSliderContent':
             uk_tz = pytz.timezone('Europe/London')
             time_fmt = ' '.join((xbmc.getRegion('dateshort'), xbmc.getRegion('time')))
-            items_list = page_data['newsShortformSliderContent']['items']
+            items_list = page_data['shortFormSliderContent'][0]['items']
             if hide_paid:
                 progr_list = [parsex.parse_news_collection_item(news_item, uk_tz, time_fmt)
                               for news_item in items_list
@@ -189,7 +195,11 @@ def collection_content(url=None, slider=None, hide_paid=False):
                 progr_list = [parsex.parse_trending_collection_item(trending_item) for trending_item in items_list]
 
         else:
-            items_list = page_data['editorialSliders'][slider]['collection']['shows']
+            try:
+                items_list = page_data['editorialSliders'][slider]['collection']['shows']
+            except KeyError:
+                logger.error("Failed to parse collection content: Unknown slider '%s'", slider)
+                return []
             if hide_paid:
                 progr_list = [parsex.parse_collection_item(item) for item in items_list if not item.get('isPaid')]
             else:
@@ -263,10 +273,10 @@ def category_news(path):
     data = get_page_data(path, cache_time=86400).get('newsData')
     if not data:
         return []
-    items = [{'label': 'Latest stories', 'params': {'path': path, 'subcat': 'heroAndLatestData'}}]
+    items = [{'label': 'Latest Stories', 'params': {'path': path, 'subcat': 'heroAndLatestData'}}]
     items.extend({'label': item['title'], 'params': {'path': path, 'subcat': 'curatedRails', 'rail': item['title']}}
                  for item in data['curatedRails'])
-    items.extend(({'label': 'Programmes', 'params': {'path': path, 'subcat': 'longformData'}},))
+    items.extend(({'label': 'Latest Programmes', 'params': {'path': path, 'subcat': 'longformData'}},))
     return items
 
 

--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -184,6 +184,7 @@ def parse_news_collection_item(news_item, time_zone, time_fmt):
     """Parse data found in news collection and in short news clips from news sub-categories
 
     """
+
     if 'encodedProgrammeId' in news_item.keys():
         # The news item is a 'normal' catchup title. Is usually just the latest ITV news.
         # Do not use field 'href' as it is known to have non-a-encoded program and episode Id's which doesn't work.
@@ -193,7 +194,7 @@ def parse_news_collection_item(news_item, time_zone, time_fmt):
                         news_item.get('encodedEpisodeId', {}).get('letterA', ''))).rstrip('/')
     else:
         # This news item is a 'short item', aka 'news clip'.
-        url = 'https://www.itv.com/watch/news/' + news_item['href']
+        url = '/'.join(('https://www.itv.com/watch/news', news_item['titleSlug'], news_item['episodeId']))
 
     # dateTime field occasionally has milliseconds. Strip these when present.
     item_time = pytz.UTC.localize(utils.strptime(news_item['dateTime'][:19], '%Y-%m-%dT%H:%M:%S'))
@@ -205,12 +206,13 @@ def parse_news_collection_item(news_item, time_zone, time_fmt):
     if news_item.get('isPaid'):
         plot = premium_plot(plot)
 
+    # TODO: consider adding poster image, but it is not always present
     return {
         'playable': True,
         'show': {
             'label': title,
             'art': {'thumb': news_item['imageUrl'].format(**IMG_PROPS_THUMB)},
-            'info': {'plot': plot, 'sorttitle': sort_title(title)},
+            'info': {'plot': plot, 'sorttitle': sort_title(title), 'duration': news_item.get('duration')},
             'params': {'url': url }
         }
     }

--- a/test/local/test_itvx.py
+++ b/test/local/test_itvx.py
@@ -121,11 +121,11 @@ class MainPageItem(TestCase):
 class Collections(TestCase):
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
     def test_collection_news(self, _):
-        items = list(itvx.collection_content(slider='newsShortformSliderContent'))
+        items = list(itvx.collection_content(slider='shortFormSliderContent'))
         self.assertGreater(len(items), 10)
         for item in items:
             has_keys(item, 'playable', 'show')
-        items2 = list(itvx.collection_content(slider='newsShortformSliderContent', hide_paid=True))
+        items2 = list(itvx.collection_content(slider='shortFormSliderContent', hide_paid=True))
         self.assertListEqual(items, items2)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
@@ -145,6 +145,11 @@ class Collections(TestCase):
             has_keys(item, 'playable', 'show')
         items2 = list(itvx.collection_content(slider='editorialRailSlot1', hide_paid=True))
         self.assertListEqual(items, items2)
+
+    @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
+    def test_non_existing_collection_from_main_page(self, _):
+        items = list(itvx.collection_content(slider='SomeNonExistingSlider'))
+        self.assertListEqual([], items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/collection_just-in_data.json'))
     def test_collection_from_collection_page(self, _):

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -77,7 +77,7 @@ class Collections(TestCase):
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
     def test_get_collection_news(self, _):
-        shows = list(filter(None, main.list_collection_content.test(slider='newsShortformSliderContent')))
+        shows = list(filter(None, main.list_collection_content.test(slider='shortFormSliderContent')))
         self.assertGreater(len(shows), 10)
         for item in shows:
             self.assertIsInstance(item, Listitem)
@@ -156,7 +156,7 @@ class Categories(TestCase):
         """News now returns a list of sub categories."""
         items = main.list_category.test('category/news')
         self.assertIsInstance(items, list)
-        self.assertEqual(6, len(items))
+        self.assertEqual(7, len(items))
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_news.json'))
     def test_sub_category_news_hero_items(self, _):
@@ -169,7 +169,7 @@ class Categories(TestCase):
         """These are in fact the tv shows in the category news."""
         items = main.list_news_sub_category.test('my/url', 'longformData', None)
         self.assertIsInstance(items, list)
-        self.assertEqual(8, len(items))
+        self.assertEqual(10, len(items))
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_news.json'))
     def test_sub_category_news_rails(self, _):
@@ -291,7 +291,6 @@ class PlayStreamLive(TestCase):
         # Assert channel name is converted to a full url
         self.assertEqual(1, len(p_req_strm.call_args_list))
         self.assertTrue(object_checks.is_url(p_req_strm.call_args_list[0], '/ITV'))
-
     @patch('resources.lib.fetch.post_json', return_value=open_json('playlists/pl_itv1.json'))
     def test_play_stream_live_without_credentials(self, _):
         itv_account.itv_session().log_out()

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -106,16 +106,18 @@ class Generic(unittest.TestCase):
         is_li_compatible_dict(self, item['show'])
 
     def test_parse_news_collection_item(self):
-        data = open_json('html/index-data.json')['newsShortformSliderContent']['items']
+        data = open_json('html/index-data.json')['shortFormSliderContent'][0]['items']
         tz_uk = pytz.timezone('Europe/London')
         # a short new item
         item = parsex.parse_news_collection_item(data[1], tz_uk, "%H-%M-%S")
         has_keys(item, 'playable', 'show')
         is_li_compatible_dict(self, item['show'])
+        # NOTE: As of 20-7-23 all news collection item appear to have the same structure
+        #       Just need to test a bit longer to be sure.
         # a new item like a normal catchup episode
-        item = parsex.parse_news_collection_item(data[-1], tz_uk, "%H-%M-%S")
-        has_keys(item, 'playable', 'show')
-        is_li_compatible_dict(self, item['show'])
+        # item = parsex.parse_news_collection_item(data[-1], tz_uk, "%H-%M-%S")
+        # has_keys(item, 'playable', 'show')
+        # is_li_compatible_dict(self, item['show'])
 
     def test_parse_trending_collection_item(self):
         data = open_json('html/index-data.json')['trendingSliderContent']['items']

--- a/test/support/object_checks.py
+++ b/test/support/object_checks.py
@@ -250,22 +250,27 @@ def check_news_collection_stream_info(playlist):
     assert is_url(video_inf['Base'] + strm_inf[0]['Href'], '.mp4')
 
 
-def check_news_category_clip_item(item):
-    """Check the content of a news clip from category 'News'
+def check_news_clip_item(item):
+    """Check the content of a news clip from collection or category 'News'
 
-    Hero items have an extra field `posterImage`, but it's not used in the addon.
+    Items from collection or from Hero of category have an extra field `posterImage`, but it's not used in the addon.
     """
     has_keys(
         item,
-        'episodeTitle', 'episodeId', 'titleSlug', 'href', 'imageUrl', 'dateTime',
+        'episodeTitle', 'episodeId', 'titleSlug', 'imageUrl', 'dateTime',
         obj_name=item['episodeTitle'])
-    expect_keys(item, 'duration', 'synopsis', obj_name=item['episodeTitle'])
+    # Some items, in particular hero items referring to a whole programme, like ITV Evening News, have a slightly
+    # different structure. Recognisable by the presence of e.g. encodedProgrammeId, but similar enough to be
+    # parsable as clip, but the fields below are missing.
+    expect_keys(item, 'synopsis', 'duration', obj_name=item['episodeTitle'])
     # imagePresets is currently an empty dict.
     assert isinstance(item['imagePresets'], dict) and not item['imagePresets']
     assert isinstance(item['episodeTitle'], str) and item['episodeTitle']
     assert isinstance(item['episodeId'], str) and item['episodeId']
+    if 'encodedProgrammeId' not in item.keys():
+        # episodeId on real clips does not require letterA encoding
+        assert '/' not in item['episodeId']
     assert isinstance(item['titleSlug'], str) and item['titleSlug']
-    assert isinstance(item['href'], str) and item['href'] and not is_url(item['href'])
     assert is_url(item['imageUrl'], '.jpg') or is_url(item['imageUrl'], '.jpeg') or is_url(item['imageUrl'], '.png') \
            or is_url(item['imageUrl'], '.bmp'), \
            "item '{}' has not a valid imageUrl".format(item['episodeTitle'])

--- a/test/test_docs/html/category_news.json
+++ b/test/test_docs/html/category_news.json
@@ -74,192 +74,179 @@
     "heroAndLatestData": [
       {
         "imagePresets": {},
-        "episodeTitle": "The latest ITV News headlines - as former Prime Minister Boris Johnson resigns as MP",
+        "episodeTitle": "The latest ITV News headlines - as NatWest boss apologises to Nigel Farage",
         "episodeId": "6js5d0f",
-        "titleSlug": "the-latest-itv-news-headlines-as-former-prime-minister-boris-johnson-resigns-as-mp",
-        "href": "the-latest-itv-news-headlines-as-former-prime-minister-boris-johnson-resigns-as-mp/6js5d0f",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/vuzVEayK9xo5rJE0umaL0/a7258413c2b075d6d40e1b933ba9fbb3/ITVX_BULLETIN_THUMBNAIL.00_00_04_18.Still003.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "titleSlug": "the-latest-itv-news-headlines-as-natwest-boss-apologises-to-nigel-farage",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6Hbjrkr1wDEO4dHjdO4wpK/1a1e8ed0d6a61fa165da0a36599b934e/LU_DTRAP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
         "synopsis": "Watch a short summary of today's top stories from the ITV News team.",
-        "dateTime": "2023-06-09T23:55:00Z",
-        "duration": 113,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/6U4UZ1xoJ9rtXMczN71IkM/1ebd4de00ca019f742992bbc99ffcadf/BULLETIN_NO_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "dateTime": "2023-07-20T20:37:00Z",
+        "duration": 112,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/1oitOHUXMIYCdttQBYtqRo/4803e3ff8e4ec42db5a82e88b2760eaa/lu_poster.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Boris Johnson stands down as MP after receiving Partygate report",
-        "episodeId": "81jb2r1",
-        "titleSlug": "boris-johnson-stands-down-as-mp-after-receiving-partygate-report",
-        "href": "boris-johnson-stands-down-as-mp-after-receiving-partygate-report/81jb2r1",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1psA3v0wHJBmKunjZtx299/4afcebec89b0b61170c760e7ac7d6f7d/NEW_STRAPS_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Boris Johnson is resigning as an MP after accusing a Commons investigation into whether he misled Parliament over partygate of attempting to \"drive me out\".",
-        "dateTime": "2023-06-09T21:25:00Z",
-        "duration": 275,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/6cTIaYnoDjRJVlEBAOZ2QB/416a0d39ff5e283bc7b6e8085be1be5f/NEW_STRAPS_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "Consultant doctors strike for the first time in more than a decade",
+        "episodeId": "5npt32k",
+        "titleSlug": "consultant-doctors-strike-for-the-first-time-in-more-than-a-decade",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4WR4JHWnIn2T7SndwQ3bVt/b413fdbe46eb6f1bdd23ecb0e0db24f7/CONSULTANTS_NEW_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "Consultant doctors and hospital-based dentists have begun a two-day strike in England. NHS bosses have warned planned care will come to a \"virtual standstill\".",
+        "dateTime": "2023-07-20T17:42:00Z",
+        "duration": 295,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/1kz8ctBvi4PPFBN7JdZ2sI/2f2ccf90e6d2786e756c97b5f2284338/CONSULTANTS_CLEAN.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "What does Boris Johnson's resignation mean for the future of the Tory party?",
-        "episodeId": "7pl5fp7",
-        "titleSlug": "what-does-boris-johnsons-resignation-mean-for-the-future-of-the-tory-party",
-        "href": "what-does-boris-johnsons-resignation-mean-for-the-future-of-the-tory-party/7pl5fp7",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5QNxOvOfCCFEEtiNSCMx98/a777175f213304bc1965c4983437f088/BORIS_STUDIO_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "ITV News' Paul Brand and Anushka Asthana discuss Johnson's scathing resignation statement and what might happen next, for both Boris and the Conservative party.",
-        "dateTime": "2023-06-09T21:26:00Z",
-        "duration": 265,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/7Guzym49U8dqEtLnvEJtb2/b088c2d564393de4ef77c85c06ea5967/THUMB_PIC_FOR_STUDIO_DISCUSSION.png?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "Mortgage rates fall for the first time in two months",
+        "episodeId": "6pv78cc",
+        "titleSlug": "mortgage-rates-fall-for-the-first-time-in-two-months",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3E0iOU7YO0ZCjD0Lp8yhl/13304fcebf4772df9a8e68b29b8f5905/MORTGAGE_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "Both two and five-year fixed rates mortgages became slightly cheaper. It follows better than expected inflation figures announced yesterday. ",
+        "dateTime": "2023-07-20T17:49:00Z",
+        "duration": 105,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/50iCkrVxKmiaGshrGyII3l/dd83e8bbbc549b5f0a6025fe869837d7/MORTGAGE_NS.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Donald Trump faces 37 felony counts according to unsealed indictment",
-        "episodeId": "t6b3k66",
-        "titleSlug": "donald-trump-faces-37-felony-counts-according-to-unsealed-indictment",
-        "href": "donald-trump-faces-37-felony-counts-according-to-unsealed-indictment/t6b3k66",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6bLLrtldJYkACEEb6TyL9D/72da3a5785b2a5302ee6a085f57fc9c4/TRUMPPPP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "The former U.S. President posted on social media suggesting the charges were linked to the handling of classified documents and said he was \"an innocent man\".",
-        "dateTime": "2023-06-09T21:30:00Z",
-        "duration": 354,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/3TiAuDLSpfrVeh7NLHhEAA/117541eeee527cb537f4ab1efd41869e/PA-72014179.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "20,000 RMT members walk out in latest rail strike at start of school holidays",
+        "episodeId": "79v86rg",
+        "titleSlug": "20000-rmt-members-walk-out-in-latest-rail-strike-at-start-of-school-holidays",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7gFqx4wggeCj1vWbA486aQ/01238fd6cf2161fbaa001b57e9d057b6/ITVX_THUMB_LTN_RAIL_STRIKES_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "Members of the RMT union at 14 rail companies are walking out until Sunday. And members of ASLEF are refusing to work overtime.",
+        "dateTime": "2023-07-20T17:51:00Z",
+        "duration": 119,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/G06dBSViYGuxrR6QgJG8a/b10c164772d059dcca30f1dd8aece01d/2.72455090.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Hotter in the UK than in Tenerife? Heat health warning comes into force",
-        "episodeId": "vrk9gvz",
-        "titleSlug": "hotter-in-the-uk-than-in-tenerife-heat-health-warning-comes-into-force",
-        "href": "hotter-in-the-uk-than-in-tenerife-heat-health-warning-comes-into-force/vrk9gvz",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5c0HDvOTDyfXMcpQDPevJs/e36c3c1b789cb94fd4cf59c8e214e100/HEAT_STRAP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Parts of England are predicted to reach temperatures of around 30 degrees, with amber heat alerts in force for some until Monday morning.",
-        "dateTime": "2023-06-09T21:39:00Z",
-        "duration": 157,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/5fdsNvJiuoIyEisGaVDLSk/d8cab2c9add78089645b129e0c0e15a4/HEAT_NO.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "Temperatures in America's Death Valley continue to soar after one tourist dies",
+        "episodeId": "v9mbwpr",
+        "titleSlug": "temperatures-in-americas-death-valley-continue-to-soar-after-one-tourist-dies",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/wOfCBfpMQyJeHhSeofl0L/f99e2e58406647ef5d10138ece06df22/death_valley.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "Temperatures in Death Valley, in California have soared higher than 50C in recent days as the world struggles with record-breaking heat.",
+        "dateTime": "2023-07-20T17:59:00Z",
+        "duration": 269,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/2TvcPeNBG9snXVQWA43wdU/71fc78a5d2305fb9f30ba84190468e73/dan_pic.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Ask ITV: Your questions answered on the Amber heat alert",
-        "episodeId": "n2gmlx5",
-        "titleSlug": "ask-itv-your-questions-answered-on-the-amber-heat-alert",
-        "href": "ask-itv-your-questions-answered-on-the-amber-heat-alert/n2gmlx5",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3kdDSZxCVWpfH0QL8Vq5th/b4ab989f56e3ecd4fd914f48102d157f/ask_itv_final_thumb.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "ITV viewers across the country have been asking what the amber heat alerts mean. Our science correspondent Martin Stew has the answers for you.",
-        "dateTime": "2023-06-09T17:37:16.53Z",
-        "duration": 326,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/6BZvUCy7zMl5rZ7zrsGtEp/31420ee40f036311ae2f82099f086674/ASK_ITV_2.png?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "New Zealand wins opening World Cup match hours after deadly shooting",
+        "episodeId": "jszms5y",
+        "titleSlug": "new-zealand-wins-opening-world-cup-match-hours-after-deadly-shooting",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/LWRCQ6UW6uWJWD8ywevwb/a686a9e816f311a8f20f6d3299ad2548/AUCKLAND_THUMB_TEXT.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "The shooting saw silences held before kick off in the opening games, in which both host nations won their matches.",
+        "dateTime": "2023-07-20T18:13:00Z",
+        "duration": 159,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/2R4oTVyhvjNiDIv8vpSkTu/409e4d12c1b3d798796c66a60bd9a86a/AUCKLAND_SPLIT_.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Putin says Russian tactical nuclear weapons to be deployed on European soil",
-        "episodeId": "w86mh40",
-        "titleSlug": "putin-says-russian-tactical-nuclear-weapons-to-be-deployed-on-european-soil",
-        "href": "putin-says-russian-tactical-nuclear-weapons-to-be-deployed-on-european-soil/w86mh40",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1VnUqNtEudGO4QzXjA45RR/5b6691467070d496fbc37da80cbab5cc/NUCLEAR_WEAPONS_THBUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Russia will start deploying tactical nuclear weapons in Belarus after special storage facilities are made ready, President Vladimir Putin announced.",
-        "dateTime": "2023-06-09T21:29:00Z",
-        "duration": 179,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/3fAGxsBhT4Wg2S0mUXszSP/945212bc67b70897e88a7a15ba72a85f/AP23160626179855.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "What's the story behind Nigel Farage and his bank account closure?",
+        "episodeId": "t406bsl",
+        "titleSlug": "whats-the-story-behind-nigel-farage-and-his-bank-account-closure",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/47sPXkslFsylEs5Jcqycpy/832ac90219613ccc175453f38f350b58/farage_thumb.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "The prestigious bank, Coutts, closed the former Brexit party leader's account with them earlier this year, prompting backlash from MPs and even the PM.",
+        "dateTime": "2023-07-20T20:16:00Z",
+        "duration": 148,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/4Q6zpuS0Yzc11yzuKizPbi/13997c099414a0abbf17805116bd1ed3/farage_no_s.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Youth unemployment in China almost doubles since 2019",
-        "episodeId": "mr62dxf",
-        "titleSlug": "youth-unemployment-in-china-almost-doubles-since-2019",
-        "href": "youth-unemployment-in-china-almost-doubles-since-2019/mr62dxf",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2qv5mzeJtOXVY8sdHdEPtP/b25757c10737a7abac7e82125afcb887/CHINESE_YOUTH_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "In the first quarter of 2019 it was 11.3%, now it has risen to 20.4%. More and more students are graduating, but since the pandemic there are not enough jobs.",
-        "dateTime": "2023-06-09T21:36:00Z",
-        "duration": 232,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/5FuXPL1r4NpQVlUKsY5r1I/86333c16bec00361a4e89b4467181c6f/CHINESE_YOUTH.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "The journey of women's football: From outright ban to record Women's World Cup",
+        "episodeId": "lg1k27m",
+        "titleSlug": "the-journey-of-womens-football-from-outright-ban-to-record-womens-world-cup",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/35YLqJ6E4TZrEG7Nh7CY2B/6c9bf51414b5682f941188e43e216188/football_3.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "After their memorable win at the Euros last year, England's Lionesses have become household names - but the journey to get there hasn't been an easy one.",
+        "dateTime": "2023-07-20T11:50:00Z",
+        "duration": 177,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/zs7JSO4mLMgrWIyKrdrhD/d62caad880b7fef78bab3f6646966c13/FOOTBALL_NEW.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Students injured and one arrested in 'serious assault' at private school in Devon",
-        "episodeId": "5y0zg63",
-        "titleSlug": "students-injured-and-one-arrested-in-serious-assault-at-private-school-in-devon",
-        "href": "students-injured-and-one-arrested-in-serious-assault-at-private-school-in-devon/5y0zg63",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/XS12gmsV6m98m9VH0YGAR/a5db39d922fbccee451495744c03f3eb/DEVON_STRAP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Three people are in hospital after being injured in a 'serious assault' at Blundell's School in Tiverton on Friday morning. A teenager has been arrested.",
-        "dateTime": "2023-06-09T17:47:00Z",
-        "duration": 113,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/5MhYCWOxe5EglI1jg5Ujj9/b3b356bfa51c981441df9308283f5cff/DEVON_NO.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "ITV News survey finds anti-Muslim hate crimes have doubled to a record high",
+        "episodeId": "y56h16f",
+        "titleSlug": "itv-news-survey-finds-anti-muslim-hate-crimes-have-doubled-to-a-record-high",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4Jf1tZqLIqKp5OhaLyhGtV/9b84980f8be015c9ab9b31f292b74038/ABUSE_FINAL.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "Organisation 'Tell Mama' and ITV News carried out a survey of 117 mosques, finding 90% had been subjected to hate crimes, including physical violence.",
+        "dateTime": "2023-07-20T18:12:00Z",
+        "duration": 321,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/4MTWFrvrqScuJTwrMMfMF/978e14c4e0439afe9ed9035e628ef9c1/MUSLIM_POSTER.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Alps stabbing attack: Emmanuel Macron visits victims and families in hospital",
-        "episodeId": "59hd21s",
-        "titleSlug": "alps-stabbing-attack-emmanuel-macron-visits-victims-and-families-in-hospital",
-        "href": "alps-stabbing-attack-emmanuel-macron-visits-victims-and-families-in-hospital/59hd21s",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1RIjXxhoxgPkUTyZ8nn0SD/814ea14d8d7e3f4ebc595c4f82355c7d/park_strap.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Emmanuel Macron travelled to the hospital treating three of the four children who suffered life-threatening injuries. A British child is in a stable condition.",
-        "dateTime": "2023-06-09T18:17:00Z",
-        "duration": 242,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/2ds1FMh0YZYmT7XLAxVw4s/04dd84d6646cd302789c10cfd99e9c51/daytime_strap.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "Huge police operation as authorities hunt 'escaped lion' in Berlin ",
+        "episodeId": "spdcy10",
+        "titleSlug": "huge-police-operation-as-authorities-hunt-escaped-lion-in-berlin",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3WJhtAM43dGeyidpMNCLFf/e0f69c40abf6debf2eeafce83c70f6fd/LION.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "Police were alerted to the animal just outside Berlin's city limits by people reporting that they had seen what appeared to be a big cat .",
+        "dateTime": "2023-07-20T18:24:00Z",
+        "duration": 123,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/6IIXMfGMde6DxtcIXWejmh/f62577a2337a49ffa70d66fcc0f1f0cd/LION_NO_STRAP.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Beverley Knight's tribute to parents in Windrush 75 concert",
-        "episodeId": "r65z7vp",
-        "titleSlug": "beverley-knights-tribute-to-parents-in-windrush-75-concert",
-        "href": "beverley-knights-tribute-to-parents-in-windrush-75-concert/r65z7vp",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6EXJCM91omZeC5r5bYvYvy/f3d593ffa2c9c76ed795d797ae97b707/BEVERLY_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "On stage at the Royal Albert Hall, marking the 75th anniversary of Windrush, Knight said she was thinking of her parents and their 'resilience'.",
-        "dateTime": "2023-06-09T21:42:00Z",
-        "duration": 194,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/30lQdlKlwQMMPvds3JOYJv/0a7dc267bbe0e3d9f459d82bdf25721a/2.2091056.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
+        "episodeTitle": "How difficult is it to travel on holiday sustainably? ",
+        "episodeId": "hjjmvm8",
+        "titleSlug": "how-difficult-is-it-to-travel-on-holiday-sustainably",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1EHzrqvA2WDv76Pe716MQT/b7c70fe0ff9a4d85e7543958818cff6e/TRAINVPLANE_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "Greenpeace are calling on the government to ban short-haul flights as southern Europe feels the scorching impact of climate change. ",
+        "dateTime": "2023-07-20T15:37:00Z",
+        "duration": 111,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/6iiATUhJoNGmxgIWT76In5/12c19107ce47d7c0415e166c7891cec8/TRAIN_NO_S.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Hot and humid: The latest ITV Weather forecast",
+        "episodeTitle": "Sunny spells and scattered showers: The latest ITV Weather",
         "episodeId": "t6r5brk",
-        "titleSlug": "hot-and-humid-the-latest-itv-weather-forecast",
-        "href": "hot-and-humid-the-latest-itv-weather-forecast/t6r5brk",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5sFO5PZRXmzaqAEOEZFwQw/061ea04a1bfdb2e23dd7d451814169eb/AMANDA_WEATHER.png?w={width}&h={height}&q={quality}&fm={image_format}",
+        "titleSlug": "sunny-spells-and-scattered-showers-the-latest-itv-weather",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7fl401gxYnSc7iHF2D7A0N/b57743a6d09e1edb981f48bc674bce46/WEATHERF.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
         "synopsis": "Watch the latest UK forecast from the ITV Weather team.",
-        "dateTime": "2023-06-09T21:47:00Z",
-        "duration": 63,
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/5sFO5PZRXmzaqAEOEZFwQw/061ea04a1bfdb2e23dd7d451814169eb/AMANDA_WEATHER.png?w={width}&h={height}&q={quality}&fm={image_format}"
+        "dateTime": "2023-07-20T18:16:00Z",
+        "duration": 105,
+        "posterImage": "https://images.ctfassets.net/go68aep20o4s/7MaWXmgQPE2UgKGXzaTUt3/552f790cd7901cad21c7dcfa39846599/LUCY.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
       },
       {
         "imagePresets": {},
-        "episodeTitle": "Watch Thursday's ITV News at Ten",
+        "episodeTitle": "Watch Thursday's ITV Evening News",
         "encodedEpisodeId": {
-          "letterA": "2a4409a1958",
-          "underscore": "2_4409_1958"
+          "letterA": "2a4545a1966",
+          "underscore": "2_4545_1966"
         },
         "encodedProgrammeId": {
-          "letterA": "2a4409",
-          "underscore": "2_4409"
+          "letterA": "2a4545",
+          "underscore": "2_4545"
         },
-        "titleSlug": "watch-thursdays-itv-news-at-ten",
-        "programmeTitle": "ITV News at Ten",
-        "episodeId": "2/4409/1958",
-        "programmeId": "2/4409",
-        "href": "watch-thursdays-itv-news-at-ten/2/4409/2/4409/1958",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3FuCS6o0owkPt4IT4WTGYk/6096186467035813b954196505135300/itvx_thumb_news_at_ten.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "dateTime": "2023-06-09T22:07:00Z"
+        "titleSlug": "watch-thursdays-itv-evening-news",
+        "programmeTitle": "ITV Evening News",
+        "episodeId": "2/4545/1966",
+        "programmeId": "2/4545",
+        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4UUItmaMdU87plHxghoGdZ/2dc5da2c0af26a0172a6a231c1930004/LUCREZIA_PROGRAMME_THUMBNAIL.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "dateTime": "2023-07-20T19:00:00Z"
       }
     ],
     "longformData": [
       {
-        "title": "ITV News at Ten",
-        "titleSlug": "itv-news-at-ten",
+        "title": "Tonight",
+        "titleSlug": "tonight",
         "encodedProgrammeId": {
-          "letterA": "2a4409",
-          "underscore": "2_4409"
+          "letterA": "1a2803",
+          "underscore": "1_2803"
         },
         "channel": "itv",
         "encodedEpisodeId": {
-          "letterA": "2a4409a1958",
-          "underscore": "2_4409_1958"
+          "letterA": "1a2803a9376",
+          "underscore": "1_2803_9376"
         },
-        "description": "The latest news from ITV News at Ten.",
-        "imageTemplate": "https://ovp.itv.com/images/programme/jkv8vj9/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
-        "contentInfo": "Series 7",
+        "description": "Compelling current affairs stories that get to the heart of what matters",
+        "imageTemplate": "https://ovp.itv.com/images/programme/2sqyd7n/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+        "contentInfo": "Series 25",
         "partnership": null,
         "contentOwner": null,
         "tier": [
           "FREE"
         ],
-        "broadcastDateTime": "2023-06-09T21:00:00Z",
-        "episodeId": "2/4409/1958",
-        "programmeId": "2/4409"
+        "broadcastDateTime": "2023-07-20T19:30:00Z",
+        "episodeId": "1/2803/9376",
+        "programmeId": "1/2803"
       },
       {
         "title": "ITV Evening News",
@@ -270,8 +257,8 @@
         },
         "channel": "itv",
         "encodedEpisodeId": {
-          "letterA": "2a4545a1937",
-          "underscore": "2_4545_1937"
+          "letterA": "2a4545a1966",
+          "underscore": "2_4545_1966"
         },
         "description": "All the latest news from the ITV Evening News team",
         "imageTemplate": "https://ovp.itv.com/images/programme/z4778t5/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
@@ -281,8 +268,8 @@
         "tier": [
           "FREE"
         ],
-        "broadcastDateTime": "2023-06-09T17:30:00Z",
-        "episodeId": "2/4545/1937",
+        "broadcastDateTime": "2023-07-20T17:30:00Z",
+        "episodeId": "2/4545/1966",
         "programmeId": "2/4545"
       },
       {
@@ -294,8 +281,8 @@
         },
         "channel": "itv",
         "encodedEpisodeId": {
-          "letterA": "2a3211a3582",
-          "underscore": "2_3211_3582"
+          "letterA": "2a3211a3611",
+          "underscore": "2_3211_3611"
         },
         "description": "BAFTA-nominated breakfast show covering the latest news, sport & weather",
         "imageTemplate": "https://ovp.itv.com/images/programme/m3kf9ck/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
@@ -305,9 +292,33 @@
         "tier": [
           "FREE"
         ],
-        "broadcastDateTime": "2023-06-09T05:00:00Z",
-        "episodeId": "2/3211/3582",
+        "broadcastDateTime": "2023-07-20T05:00:00Z",
+        "episodeId": "2/3211/3611",
         "programmeId": "2/3211"
+      },
+      {
+        "title": "ITV News at Ten",
+        "titleSlug": "itv-news-at-ten",
+        "encodedProgrammeId": {
+          "letterA": "2a4409",
+          "underscore": "2_4409"
+        },
+        "channel": "itv",
+        "encodedEpisodeId": {
+          "letterA": "2a4409a1986",
+          "underscore": "2_4409_1986"
+        },
+        "description": "The latest news from ITV News at Ten.",
+        "imageTemplate": "https://ovp.itv.com/images/programme/jkv8vj9/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+        "contentInfo": "Series 7",
+        "partnership": null,
+        "contentOwner": null,
+        "tier": [
+          "FREE"
+        ],
+        "broadcastDateTime": "2023-07-19T21:00:00Z",
+        "episodeId": "2/4409/1986",
+        "programmeId": "2/4409"
       },
       {
         "title": "King Charles III: The Coronation",
@@ -334,30 +345,6 @@
         "programmeId": "10/4617"
       },
       {
-        "title": "Tonight",
-        "titleSlug": "tonight",
-        "encodedProgrammeId": {
-          "letterA": "1a2803",
-          "underscore": "1_2803"
-        },
-        "channel": "itv",
-        "encodedEpisodeId": {
-          "letterA": "1a2803a9372",
-          "underscore": "1_2803_9372"
-        },
-        "description": "Compelling current affairs stories that get to the heart of what matters",
-        "imageTemplate": "https://ovp.itv.com/images/programme/2sqyd7n/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
-        "contentInfo": "Series 25, 25",
-        "partnership": null,
-        "contentOwner": null,
-        "tier": [
-          "FREE"
-        ],
-        "broadcastDateTime": "2023-06-08T19:30:00Z",
-        "episodeId": "1/2803/9372",
-        "programmeId": "1/2803"
-      },
-      {
         "title": "Peston",
         "titleSlug": "peston",
         "encodedProgrammeId": {
@@ -366,8 +353,8 @@
         },
         "channel": "itv",
         "encodedEpisodeId": {
-          "letterA": "2a4458a0290",
-          "underscore": "2_4458_0290"
+          "letterA": "2a4458a0296",
+          "underscore": "2_4458_0296"
         },
         "description": "ITV News' Robert Peston presents his lively political interview programme",
         "imageTemplate": "https://ovp.itv.com/images/programme/ypjrr23/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
@@ -377,8 +364,8 @@
         "tier": [
           "FREE"
         ],
-        "broadcastDateTime": "2023-06-07T21:45:00Z",
-        "episodeId": "2/4458/0290",
+        "broadcastDateTime": "2023-07-19T21:45:00Z",
+        "episodeId": "2/4458/0296",
         "programmeId": "2/4458"
       },
       {
@@ -426,6 +413,52 @@
         ],
         "broadcastDateTime": null,
         "programmeId": "10/4617"
+      },
+      {
+        "title": "The Clinic",
+        "titleSlug": "the-clinic",
+        "encodedProgrammeId": {
+          "letterA": "10a3894",
+          "underscore": "10_3894"
+        },
+        "channel": "itv2",
+        "encodedEpisodeId": {
+          "letterA": "",
+          "underscore": ""
+        },
+        "description": "Timely documentary about the history of a controversial NHS unit",
+        "imageTemplate": "https://ovp.itv.com/images/special/zpc6shq/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+        "contentInfo": "1h 5m",
+        "partnership": null,
+        "contentOwner": null,
+        "tier": [
+          "FREE"
+        ],
+        "broadcastDateTime": null,
+        "programmeId": "10/3894"
+      },
+      {
+        "title": "Thur 13 July 6am",
+        "titleSlug": "thur-13-july-6am",
+        "encodedProgrammeId": {
+          "letterA": "2a3211",
+          "underscore": "2_3211"
+        },
+        "channel": "itv",
+        "encodedEpisodeId": {
+          "letterA": "",
+          "underscore": ""
+        },
+        "description": "As Huw Edwards is named in the BBC crisis, Jon Sopel discusses the latest developments.",
+        "imageTemplate": "https://ovp.itv.com/images/episode/d5wwh9v/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+        "contentInfo": "",
+        "partnership": null,
+        "contentOwner": null,
+        "tier": [
+          "FREE"
+        ],
+        "broadcastDateTime": null,
+        "programmeId": "2/3211"
       }
     ],
     "curatedRails": [
@@ -434,135 +467,123 @@
         "clips": [
           {
             "imagePresets": {},
-            "episodeTitle": "Boris Johnson receives findings of Parliament's Partygate investigation",
-            "episodeId": "y50g2qj",
-            "titleSlug": "boris-johnson-receives-findings-of-parliaments-partygate-investigation",
-            "href": "boris-johnson-receives-findings-of-parliaments-partygate-investigation/y50g2qj",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5fxsmcSsQ14WdRuERUemjP/d48b0045052b18b1eb30e55758cb9367/boris_thumb_version_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The former Prime Minister was questioned in March by the Privileges Committee, on whether he misled MPs over Partygate. Johnson now has a draft of its report.",
-            "dateTime": "2023-06-08T21:41:00Z",
-            "duration": 94
+            "episodeTitle": "Protests as controversial barge to house asylum seekers docks in Portland",
+            "episodeId": "vkxh0xn",
+            "titleSlug": "protests-as-controversial-barge-to-house-asylum-seekers-docks-in-portland",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3If2ZfhFBMqOZQxI1gDheQ/414397c1ec9b4d0c304d844905a83ab8/BIBBY_LATEST_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The Bibby Stockholm barge, that will be used to house more than 500 asylum seekers, has docked in Dorset - to scenes of protesters with very different opinions.",
+            "dateTime": "2023-07-18T18:00:00Z",
+            "duration": 224
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Rishi Sunak and Joe Biden announce new partnership to boost economic security",
-            "episodeId": "kryp2vd",
-            "titleSlug": "rishi-sunak-and-joe-biden-announce-new-partnership-to-boost-economic-security",
-            "href": "rishi-sunak-and-joe-biden-announce-new-partnership-to-boost-economic-security/kryp2vd",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1odBOl4b3Ls0RbY2Ry4dX6/648470e5b598fd301903a9287d57f84d/ska_etn.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The Atlantic Declaration, announced at the White House, falls short of a full free trade deal. UK officials says it's a better response to current challenges.",
-            "dateTime": "2023-06-08T21:24:00Z",
-            "duration": 450
+            "episodeTitle": "Rail ticket office closures: Andy Burnham leading a legal challenge",
+            "episodeId": "hjvhp1v",
+            "titleSlug": "rail-ticket-office-closures-andy-burnham-leading-a-legal-challenge",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1G3NbNamphrPvbYrxZRf5i/316906f68785d95edfbc389a6cd35269/ticket_office_thumb_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Five Labour mayors are joining forces to challenge plans to close up to 1,000 rail ticket offices in England and say a consultation period was not long enough.",
+            "dateTime": "2023-07-18T18:22:00Z",
+            "duration": 125
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Green Party's only MP Caroline Lucas to stand down at the next election",
-            "episodeId": "nq3mh61",
-            "titleSlug": "green-partys-only-mp-caroline-lucas-to-stand-down-at-the-next-election",
-            "href": "green-partys-only-mp-caroline-lucas-to-stand-down-at-the-next-election/nq3mh61",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/10cRojII0egVW6wLFT1NHZ/c8e0670556669b3c246a34b54a99d64a/caroline_lucas.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Caroline Lucas has said her role in Parliament has meant she has \"struggled to spend the time I want\" on climate concerns and the environment.",
-            "dateTime": "2023-06-08T07:14:00Z",
-            "duration": 21
+            "episodeTitle": "Prime Minister to cap student numbers on 'poor quality' university degrees",
+            "episodeId": "pbznn3c",
+            "titleSlug": "prime-minister-to-cap-student-numbers-on-poor-quality-university-degrees",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3MTWxVFQevvJ49AddxitCJ/6ae2453903a0bcddfe0869193c65bfdc/UNI_THUMB_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The government has said limits may be imposed on courses that have high dropout rates or that lead to a low proportion of graduates getting a professional job.",
+            "dateTime": "2023-07-17T12:55:00Z",
+            "duration": 125
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Chair of Covid-19 Inquiry says it should be her decision which material is relevant",
-            "episodeId": "4b3rh5j",
-            "titleSlug": "chair-of-covid-19-inquiry-says-it-should-be-her-decision-which-material-is-relevant",
-            "href": "chair-of-covid-19-inquiry-says-it-should-be-her-decision-which-material-is-relevant/4b3rh5j",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6u03j1QztHPERRJjkeaKu5/b565d120d2052a94fd6b64007ad655b0/COVID_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Baroness Hallett reacted to the Cabinet Office's decision to block full access to Boris Johnson's WhatsApp messages from when he was Prime Minister.",
-            "dateTime": "2023-06-06T21:23:00Z",
-            "duration": 172
+            "episodeTitle": "Government set to break promise of forty new hospitals by 2030",
+            "episodeId": "5jw0nz1",
+            "titleSlug": "government-set-to-break-promise-of-forty-new-hospitals-by-2030",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3YzA71mZPUxCjVVdC0YQgX/9f7e2b11d0317760be7a58c7391cbb3c/HOSPITAL_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The government is set to finish only 32 of its promised new 40 hospitals by 2030, according to the spending watchdog.",
+            "dateTime": "2023-07-17T06:37:00Z",
+            "duration": 135
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Rishi Sunak insists plan to reduce small boats crossing the Channel is working",
-            "episodeId": "nc4wbz9",
-            "titleSlug": "rishi-sunak-insists-plan-to-reduce-small-boats-crossing-the-channel-is-working",
-            "href": "rishi-sunak-insists-plan-to-reduce-small-boats-crossing-the-channel-is-working/nc4wbz9",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1uMfd4okTgO6nYKRSdpekB/8f3844017b7d2867a4a2c30393f135ae/IMMIGRATION_THUMB_NEW.png?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The Prime Minister shared the progress made in the six months since he introduced the Illegal Migration Bill.",
-            "dateTime": "2023-06-05T21:25:00Z",
-            "duration": 180
+            "episodeTitle": "Ministers face nurses' wrath about getting lower public sector pay award",
+            "episodeId": "7zswzh0",
+            "titleSlug": "ministers-face-nurses-wrath-about-getting-lower-public-sector-pay-award",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1HEu2pZiZpsVnGUvAPmhru/e76992508f3ec0f4945840296802ec06/new_nurses_thumb_no_straps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The nurses' union has written to the Health Secretary about their 5 percent pay rise, agreed before higher deals were confirmed for other public sector workers.",
+            "dateTime": "2023-07-14T21:37:00Z",
+            "duration": 90
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Senior minister says migration targets are 'not helpful' after Tories miss theirs",
-            "episodeId": "dh1z0wj",
-            "titleSlug": "senior-minister-says-migration-targets-are-not-helpful-after-tories-miss-theirs",
-            "href": "senior-minister-says-migration-targets-are-not-helpful-after-tories-miss-theirs/dh1z0wj",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5yOYabxtI8NP1o5CCiUYwL/e5b7d29f0afa94e54faab8d6886db051/jenrick_v2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Immigration Minister Robert Jenrick said migration targets are not \"particularly helpful\" - despite previous Tory promises to keep figures below 100,000 a year.",
-            "dateTime": "2023-06-04T12:34:00Z",
-            "duration": 47
+            "episodeTitle": "Mortgage pain as warnings monthly payments could rise up to \u00a3500",
+            "episodeId": "ftrg3d2",
+            "titleSlug": "mortgage-pain-as-warnings-monthly-payments-could-rise-up-to-pound500",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5x3rOK8DRhbXzViwY1Sbx8/04e20fee8db4dc51e4c5183786c2b264/mortgage4_1.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The Bank of England has warned that nearly a million mortgage holders could see their monthly repayments increase by around \u00a3500 over the next three years.",
+            "dateTime": "2023-07-12T21:20:00Z",
+            "duration": 153
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Boris Johnson warned he could lose legal funding for Covid inquiry",
-            "episodeId": "yvyyghn",
-            "titleSlug": "boris-johnson-warned-he-could-lose-legal-funding-for-covid-inquiry",
-            "href": "boris-johnson-warned-he-could-lose-legal-funding-for-covid-inquiry/yvyyghn",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6yAfMx3dBptPBTpckgBCU9/20b23e5cf81725a0a2238408f44bf7fa/BORIS_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Johnson has been warned he could lose public funding for legal advice if he continues to \"frustrate or undermine\" the Government's position on the Covid inquiry",
-            "dateTime": "2023-06-04T21:53:00Z",
-            "duration": 136
+            "episodeTitle": "Thames Water boss says water bills will have to rise next year ",
+            "episodeId": "d4g845p",
+            "titleSlug": "thames-water-boss-says-water-bills-will-have-to-rise-next-year",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/y7EtYzyLz85qghVsWSjMv/267e93bb777d379456e6a83c04bd39a2/ITVX_STORY_THUMBNAIL.00_00_26_01.Still012.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The new interim boss of Thames Water has told MPs that water bills will have to increase in order to fund 'substantial' investment in the sector.",
+            "dateTime": "2023-07-12T21:29:00Z",
+            "duration": 191
           },
           {
             "imagePresets": {},
-            "episodeTitle": "The government may be about to announce funding to fill thousands of NHS vacancies",
-            "episodeId": "r1p4s6s",
-            "titleSlug": "the-government-may-be-about-to-announce-funding-to-fill-thousands-of-nhs-vacancies",
-            "href": "the-government-may-be-about-to-announce-funding-to-fill-thousands-of-nhs-vacancies/r1p4s6s",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1pP9fdWy6PkLzIZNGD8kdd/d4b6e7b7bb47a3db3f8138945ce0032a/itvx_thumb_nhs_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The government is reportedly set to announce that \u00a31bn will be spent on filling vacancies in the NHS in England. The funding would train thousands of new staff.",
-            "dateTime": "2023-06-03T21:27:00Z",
-            "duration": 117
+            "episodeTitle": "ITV News' Political Editor on wages, interest rates and what could happen next",
+            "episodeId": "sscbwt0",
+            "titleSlug": "itv-news-political-editor-on-wages-interest-rates-and-what-could-happen-next",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/z6lcT46EBGNuqnrEKH5De/cf0c40bccd9a36d33f358ae1f6e15f97/peston_live_thumb_straps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Mortgage rates have risen on the back of the Bank of England's interest rate hikes, as monetary policymakers attempt to tackle rampant inflation.",
+            "dateTime": "2023-07-11T21:40:00Z",
+            "duration": 171
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Boris Johnson says he can't access many of his pandemic Whatsapp messages",
-            "episodeId": "c3ffsdz",
-            "titleSlug": "boris-johnson-says-he-cant-access-many-of-his-pandemic-whatsapp-messages",
-            "href": "boris-johnson-says-he-cant-access-many-of-his-pandemic-whatsapp-messages/c3ffsdz",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3aby1x5hUoUHbRKeAw2J3x/7cd5a7a08c125c2a97c828dfe286b6cf/itvx_thumb_johnson_ltn.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The former PM says the security services told him not to access his old phone, after a privacy breach. The phone holds messages requested by the Covid Inquiry.",
-            "dateTime": "2023-06-02T21:20:00Z",
-            "duration": 300
+            "episodeTitle": "Wages rose by a record 7.3% in year to May in fresh blow to Bank of England",
+            "episodeId": "993sthh",
+            "titleSlug": "wages-rose-by-a-record-73percent-in-year-to-may-in-fresh-blow-to-bank-of-england",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2owOPMa5G2UQEYATfyIDAv/cb5228f4c7fff6af29d75751d55cea1e/WAGES_THUMB_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Wages in the UK  have risen at a record annual pace, fuelling fears that inflation will stay high for longer.",
+            "dateTime": "2023-07-11T08:00:00Z",
+            "duration": 82
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Plans to relax rules on academic qualifications of childcare providers",
-            "episodeId": "05b93bg",
-            "titleSlug": "plans-to-relax-rules-on-academic-qualifications-of-childcare-providers",
-            "href": "plans-to-relax-rules-on-academic-qualifications-of-childcare-providers/05b93bg",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/33sBrxBUIzJDjKBDWY4yR3/1c5cd62db342693a6b79f9b55c97787f/CHILDCARE_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The government wants more people to consider jobs in childcare as it expands its free hours provision, but critics are worried it could drive down standards.",
-            "dateTime": "2023-05-31T21:41:00Z",
-            "duration": 152
+            "episodeTitle": "U.S. President Joe Biden's trip to UK glosses over tensions on other topics",
+            "episodeId": "n9td840",
+            "titleSlug": "us-president-joe-bidens-trip-to-uk-glosses-over-tensions-on-other-topics",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7IayNfMFpWDewHB4IBZNBl/069791e576113df0c11d174c04abff30/BIDEN_1.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Downing Street said Mr Sunak discussed the United States' controversial decision to send cluster munitions to Kyiv, hours before Mr Biden met King Charles.",
+            "dateTime": "2023-07-10T21:34:00Z",
+            "duration": 183
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Government to crackdown on underage vaping after rise in e-cigarettes use",
-            "episodeId": "cdhdm4j",
-            "titleSlug": "government-to-crackdown-on-underage-vaping-after-rise-in-e-cigarettes-use",
-            "href": "government-to-crackdown-on-underage-vaping-after-rise-in-e-cigarettes-use/cdhdm4j",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5X7DwxqldD1YA2zhPraEjv/29ba47380da9aef232d4523760217eda/VAPE_THHUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Ministers plan to close a loophole allowing retailers to give free samples to children. NHS figures show 9% of those aged 11 to 15 used e-cigarettes in 2021.",
-            "dateTime": "2023-05-30T17:39:00Z",
-            "duration": 235
+            "episodeTitle": "Sunak on collision course with ministers over 'short-sighted' public sector pay rises",
+            "episodeId": "7kf2175",
+            "titleSlug": "sunak-on-collision-course-with-ministers-over-short-sighted-public-sector-pay-rises",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2KcPlxjkpwasfl0ufiBIXN/50724ead4c52250bfea2bd3166e9d36e/GOV_DISPUT_THUMB_PR.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The Prime Minister is under pressure from his own cabinet to accept the recommendations of pay review bodies, but he insists they must be 'affordable'. ",
+            "dateTime": "2023-07-08T18:15:00Z",
+            "duration": 121
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Ministers asking supermarkets to consider cutting prices on basic food items",
-            "episodeId": "rrdvtpz",
-            "titleSlug": "ministers-asking-supermarkets-to-consider-cutting-prices-on-basic-food-items",
-            "href": "ministers-asking-supermarkets-to-consider-cutting-prices-on-basic-food-items/rrdvtpz",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3eSEvJDacT0RIj7HPCktZb/7f54915f041304a0e8fcc23da1293def/SUPERMARKET_THUMB_FM.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "It's understood the agreement with major retailers would be voluntary and could see price reductions on items to help tackle the cost of living crisis.",
-            "dateTime": "2023-05-29T06:15:00Z",
-            "duration": 132
+            "episodeTitle": "Internal government row over whether to award teachers 6.5% pay rise",
+            "episodeId": "0fvm2cf",
+            "titleSlug": "internal-government-row-over-whether-to-award-teachers-65percent-pay-rise",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/22uU1yUinH6C4Q30zDaaVt/0a6117eeda139d3099c3696dfde39709/teachers_new.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "ITV News understands there is division between the Education Secretary and Treasury over whether teachers should be given the recommended pay increase.",
+            "dateTime": "2023-07-07T21:23:00Z",
+            "duration": 184
           }
         ]
       },
@@ -571,124 +592,133 @@
         "clips": [
           {
             "imagePresets": {},
-            "episodeTitle": "Donald Trump faces 37 felony counts according to unsealed indictment",
-            "episodeId": "t6b3k66",
-            "titleSlug": "donald-trump-faces-37-felony-counts-according-to-unsealed-indictment",
-            "href": "donald-trump-faces-37-felony-counts-according-to-unsealed-indictment/t6b3k66",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6bLLrtldJYkACEEb6TyL9D/72da3a5785b2a5302ee6a085f57fc9c4/TRUMPPPP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The former U.S. President posted on social media suggesting the charges were linked to the handling of classified documents and said he was \"an innocent man\".",
-            "dateTime": "2023-06-09T21:30:00Z",
-            "duration": 354
+            "episodeTitle": "Wildfires continue in Greece as southern Europe gripped by heatwave",
+            "episodeId": "wml6bj2",
+            "titleSlug": "wildfires-continue-in-greece-as-southern-europe-gripped-by-heatwave",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/25QmWkOyH4gwmGADDPwO8Z/1b3ef5419909be3297093c3be8ec9650/heatwave.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "As the Cerberus heatwave continues, hospitals in Italy say they have seen a rise in people seeking emergency care for heat-related illnesses.",
+            "dateTime": "2023-07-19T21:20:00Z",
+            "duration": 177
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Alps stabbing attack: Emmanuel Macron visits victims and families in hospital",
-            "episodeId": "59hd21s",
-            "titleSlug": "alps-stabbing-attack-emmanuel-macron-visits-victims-and-families-in-hospital",
-            "href": "alps-stabbing-attack-emmanuel-macron-visits-victims-and-families-in-hospital/59hd21s",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1RIjXxhoxgPkUTyZ8nn0SD/814ea14d8d7e3f4ebc595c4f82355c7d/park_strap.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Emmanuel Macron travelled to the hospital treating three of the four children who suffered life-threatening injuries. A British child is in a stable condition.",
-            "dateTime": "2023-06-09T18:17:00Z",
-            "duration": 242
+            "episodeTitle": "Las Vegas police issue search warrant in Tupac Shakur 1996 killing",
+            "episodeId": "wltkb1w",
+            "titleSlug": "las-vegas-police-issue-search-warrant-in-tupac-shakur-1996-killing",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6uqjzsmW60l9wIRY66D777/b701ebdfe383d9b467b8833fe740689e/ITVX_TUPAC_THUMBNAIL0.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Shakur died after after being shot several times inside a black vehicle stopped near the Las Vegas strip",
+            "dateTime": "2023-07-19T02:52:39.2Z",
+            "duration": 88
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Ukrainian residents trapped by floods as fears grow over dislodged landmines ",
-            "episodeId": "bwr32sl",
-            "titleSlug": "ukrainian-residents-trapped-by-floods-as-fears-grow-over-dislodged-landmines",
-            "href": "ukrainian-residents-trapped-by-floods-as-fears-grow-over-dislodged-landmines/bwr32sl",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/58c1GFymuHiTdjnOPh3dJg/c9b5608e7a0c4d7027f0fb18ce3d325d/LANDMINES.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The Red Cross says floodwater from a destroyed dam in Ukraine has uprooted landmines, which will pose a danger to civilians for decades to come.",
-            "dateTime": "2023-06-08T21:25:00Z",
-            "duration": 226
+            "episodeTitle": "Trump says he expects to be arrested as part of investigation into Capitol riots",
+            "episodeId": "xrn87gz",
+            "titleSlug": "trump-says-he-expects-to-be-arrested-as-part-of-investigation-into-capitol-riots",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3X0IgtUGmtChhv7aMdUWaV/397e5ff5daec5fddd0857b467d87c3d5/NEW_TRUMP_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The former U.S. president posted on his Truth Social platform that he's received a letter explaining he's a target of the Justice Department's investigation.",
+            "dateTime": "2023-07-18T21:14:00Z",
+            "duration": 314
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Rishi Sunak and Joe Biden announce new partnership to boost economic security",
-            "episodeId": "kryp2vd",
-            "titleSlug": "rishi-sunak-and-joe-biden-announce-new-partnership-to-boost-economic-security",
-            "href": "rishi-sunak-and-joe-biden-announce-new-partnership-to-boost-economic-security/kryp2vd",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1odBOl4b3Ls0RbY2Ry4dX6/648470e5b598fd301903a9287d57f84d/ska_etn.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The Atlantic Declaration, announced at the White House, falls short of a full free trade deal. UK officials says it's a better response to current challenges.",
-            "dateTime": "2023-06-08T21:24:00Z",
-            "duration": 450
+            "episodeTitle": "Australian state of Victoria pulls out of hosting the 2026 Commonwealth Games",
+            "episodeId": "73gl2vc",
+            "titleSlug": "australian-state-of-victoria-pulls-out-of-hosting-the-2026-commonwealth-games",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/78G5WFss6qa3TzhTuYBaI7/6977ed1d5a9e12b3ddf0eb9f322fd0a1/COMMONWEALTH.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The Premier of Victoria Daniel Andrews said he could not justify the '12 day sporting event', after the estimated cost almost tripled.",
+            "dateTime": "2023-07-18T13:30:00Z",
+            "duration": 158
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Raging wildfires in Canada spreading smoke south into U.S. and as far as Norway",
-            "episodeId": "4xs0trm",
-            "titleSlug": "raging-wildfires-in-canada-spreading-smoke-south-into-us-and-as-far-as-norway",
-            "href": "raging-wildfires-in-canada-spreading-smoke-south-into-us-and-as-far-as-norway/4xs0trm",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6OBTZlFBSSpZvxZcSnulPD/358c8d0e7e4ae93573c3eae5863fa39e/THUMV_V2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "As hundreds of wildfires continue to burn in Canada, the hazardous haze from them is disrupting daily life for millions - with many being told to stay inside.",
-            "dateTime": "2023-06-08T12:50:00Z",
-            "duration": 152
+            "episodeTitle": "Wildfires continue to burn in Greece as heat threatens people's health",
+            "episodeId": "rhq9p2y",
+            "titleSlug": "wildfires-continue-to-burn-in-greece-as-heat-threatens-peoples-health",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1DkaG8EgnHze5Y2m5RCTva/111b9fb2506fd9a42efc104c86bbe64c/new_europe_heat_thumb_straps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The UN's weather agency says the soaring temperatures in Europe could last for weeks. Twenty alerts are in place in Italy and fires are burning in Switzerland.",
+            "dateTime": "2023-07-18T21:20:00Z",
+            "duration": 229
           },
           {
             "imagePresets": {},
-            "episodeTitle": "What could the consequences be of the Ukraine dam attack?",
-            "episodeId": "l2br9n1",
-            "titleSlug": "what-could-the-consequences-be-of-the-ukraine-dam-attack",
-            "href": "what-could-the-consequences-be-of-the-ukraine-dam-attack/l2br9n1",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3ljlwul8KTdFP3JYjnF4mQ/3d1085b60418677e36b699d8c88d3061/dam_wall_tn.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The collapse of the Kakhovka dam is likely to have far-reaching and long-lasting effects on the southern region of Ukraine and beyond.",
-            "dateTime": "2023-06-07T18:45:00Z",
-            "duration": 153
+            "episodeTitle": "Two people killed in 'emergency' on bridge linking Crimea to Russia",
+            "episodeId": "rx6xqzf",
+            "titleSlug": "two-people-killed-in-emergency-on-bridge-linking-crimea-to-russia",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2kIIoNNKmpEDofHTRgROxZ/672cb6f92b224af6eb3546567d71651c/CRIME_BRIDGE_NEW_WITH_TEXT.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The governor of Russia's Belgorod region has said a man and a woman died, with their daughter also injured. Locals had reported hearing explosions.",
+            "dateTime": "2023-07-17T12:00:00Z",
+            "duration": 37
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Calls for Duke's U.S. visa records to be released over past drug-use revelations",
-            "episodeId": "p5jpf1k",
-            "titleSlug": "calls-for-dukes-us-visa-records-to-be-released-over-past-drug-use-revelations",
-            "href": "calls-for-dukes-us-visa-records-to-be-released-over-past-drug-use-revelations/p5jpf1k",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3YiNxFxLRBE3EDVv5OrWO7/7af32be918a7e12dddc2db53b9dfc14e/us_drug.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "A Conservative think tank is demanding that Prince Harry's records be unsealed to check whether he previously admitted using drugs on his U.S. visa form.",
-            "dateTime": "2023-06-06T06:14:00Z",
-            "duration": 152
+            "episodeTitle": "Why Hollywood could grind to a halt as actors join writers for strikes",
+            "episodeId": "znkc3x1",
+            "titleSlug": "why-hollywood-could-grind-to-a-halt-as-actors-join-writers-for-strikes",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6HwDHIjo7ZrKJKsmDcXMft/ba57d6ba8d675a098151f0fd4c87451e/better_hollywood_thumb_straps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Hollywood's actors' union will join writers on the picket line, potentially causing disruptions across the world and here in the UK.",
+            "dateTime": "2023-07-14T22:15:00Z",
+            "duration": 275
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Veterans remember D-Day landings on 79th anniversary of Normandy invasion",
-            "episodeId": "9rndzlm",
-            "titleSlug": "veterans-remember-d-day-landings-on-79th-anniversary-of-normandy-invasion",
-            "href": "veterans-remember-d-day-landings-on-79th-anniversary-of-normandy-invasion/9rndzlm",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7El4J6hQmzlylX5vJaKaf0/08c21d0c2ebbfca2362cbc10038e2136/D-DAY_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Services are being held today to mark 79 years since the invasion which turned the tide against Nazi Germany in World War II.",
-            "dateTime": "2023-06-06T12:57:00Z",
-            "duration": 135
+            "episodeTitle": "Damning report on UK government's response to Chinese espionage",
+            "episodeId": "tfzyvf2",
+            "titleSlug": "damning-report-on-uk-governments-response-to-chinese-espionage",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3NXPnZsUn6iIP3wdxtHVFd/e4db084dc2e30fd81bbe3afd29eea2f1/china_thumb_straps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Successive governments have failed to grasp and respond to the scale of the threat posed by China, Parliament's spy agency watchdog has found.",
+            "dateTime": "2023-07-13T21:26:00Z",
+            "duration": 265
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Miraculous rescue as sherpa carries stricken climber to safety on Mount Everest",
-            "episodeId": "kkdj1f1",
-            "titleSlug": "miraculous-rescue-as-sherpa-carries-stricken-climber-to-safety-on-mount-everest",
-            "href": "miraculous-rescue-as-sherpa-carries-stricken-climber-to-safety-on-mount-everest/kkdj1f1",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4VmXZ8onSqK5DLmdCMtgh5/5b5f442ec9dacf51b6e0477e7a0d339a/EVEREST_THUMB_PR.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "A Nepalese sherpa has saved the life of a climber who was freezing to death near the summit of the mountain, by carrying him on his back for hours.",
-            "dateTime": "2023-06-01T17:57:00Z",
-            "duration": 144
+            "episodeTitle": "NATO agree Ukraine support package as Zelenskyy warned to show 'gratitude'",
+            "episodeId": "w26kg5f",
+            "titleSlug": "nato-agree-ukraine-support-package-as-zelenskyy-warned-to-show-gratitude",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/33NtJjwWT8TDbomm0gWR6x/4aa874d8500a8c64b2ae182ef19e4ff3/nato_new_thumb.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "UK Prime Minister Rishi Sunak has moved to smooth tensions after Defence Secretary Ben Wallace made comments about Ukraine's request for weapons.",
+            "dateTime": "2023-07-12T21:26:00Z",
+            "duration": 227
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Madeleine McCann: Number of items seized in fresh search \u2018cannot yet be linked\u2019 to disappearance",
-            "episodeId": "7x0s674",
-            "titleSlug": "madeleine-mccann-number-of-items-seized-in-fresh-search-cannot-yet-be-linked-to-disappearance",
-            "href": "madeleine-mccann-number-of-items-seized-in-fresh-search-cannot-yet-be-linked-to-disappearance/7x0s674",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1fRAw4q3AyKmXFxDTKCcuh/6e864c9f09fbd3df01c36b3006823c02/MADDDFIE_1.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Police investigating the disappearance of Madeleine McCann have confirmed \"a number of items were seized\" after the recent search at a Portuguese dam.",
-            "dateTime": "2023-06-01T17:57:00Z",
-            "duration": 128
+            "episodeTitle": "Temperatures in the Mediterranean could set a European record",
+            "episodeId": "ddv69pr",
+            "titleSlug": "temperatures-in-the-mediterranean-could-set-a-european-record",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7vY8jnZ5fl9SE0uVuigFte/155424321254021f01c21bd30ab7c411/ITVX_STORY_THUMBNAIL.00_00_08_21.Still008.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Tourists are being warned to prepare as a heatwave suffocates parts of Europe. Temperatures are predicted to reach highs of up to 48 celsius in part of Italy.",
+            "dateTime": "2023-07-12T18:12:00Z",
+            "duration": 142
           },
           {
             "imagePresets": {},
-            "episodeTitle": "U.S. military criticises Chinese jet pilot's \"unnecessarily aggressive\" manoeuvre",
-            "episodeId": "sztx7st",
-            "titleSlug": "us-military-criticises-chinese-jet-pilots-unnecessarily-aggressive-manoeuvre",
-            "href": "us-military-criticises-chinese-jet-pilots-unnecessarily-aggressive-manoeuvre/sztx7st",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/23sWLADmVYDKjPD4My7m7w/9a2cb6a08a75e1e9f06bb92325cc98d9/THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "U.S. authorities say the Chinese fighter pilot flew directly in front of the nose of the American aircraft forcing it to fly through its wake turbulence.",
-            "dateTime": "2023-05-31T01:00:00Z",
-            "duration": 45
+            "episodeTitle": "Aretha Franklin note that was found under her sofa is legal will, jury rules",
+            "episodeId": "xlkxtk4",
+            "titleSlug": "aretha-franklin-note-that-was-found-under-her-sofa-is-legal-will-jury-rules",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6VvcABHC2WV5J1J3Qk06F8/76a2ccb290e7d6a8fa8d4e6b40793189/ARETHA.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The verdict comes after a four-year dispute within Ms Franklin\u2019s family to determine the late musician's intention for her estate.",
+            "dateTime": "2023-07-12T12:45:00Z",
+            "duration": 137
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "NATO agree Ukraine support package as Zelenskyy warned to show 'gratitude'",
+            "episodeId": "w26kg5f",
+            "titleSlug": "nato-agree-ukraine-support-package-as-zelenskyy-warned-to-show-gratitude",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/33NtJjwWT8TDbomm0gWR6x/4aa874d8500a8c64b2ae182ef19e4ff3/nato_new_thumb.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "UK Prime Minister Rishi Sunak has moved to smooth tensions after Defence Secretary Ben Wallace made comments about Ukraine's request for weapons.",
+            "dateTime": "2023-07-12T21:26:00Z",
+            "duration": 227
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "India, Japan and U.S. hit by floods as global sea temperatures hit record high",
+            "episodeId": "0gdhbfw",
+            "titleSlug": "india-japan-and-us-hit-by-floods-as-global-sea-temperatures-hit-record-high",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2l8JmzQAN5OZXZ5ui3ArJd/944d53403d543596586a24197472280c/FLOOD_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Extreme rainfall has caused deadly flooding across the globe, triggered by rising sea temperatures. Experts have called it an 'unprecedented peak'.",
+            "dateTime": "2023-07-11T21:42:00Z",
+            "duration": 178
           }
         ]
       },
@@ -697,146 +727,133 @@
         "clips": [
           {
             "imagePresets": {},
-            "episodeTitle": "Chilling warning from mother whose son was killed in dog attack",
-            "episodeId": "y1nlypn",
-            "titleSlug": "chilling-warning-from-mother-whose-son-was-killed-in-dog-attack",
-            "href": "chilling-warning-from-mother-whose-son-was-killed-in-dog-attack/y1nlypn",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5Wb4yRjB9JGZUTZhjM5qeg/a6781e56860359c83c60a0dcff46923a/7PM_DOG_ATTACK_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Ten-year-old Jack Lis was attacked by an XL Bully in 2021. Now his mother Emma Whitfield is campaigning for a change in the law around dangerous dogs.",
-            "dateTime": "2023-06-08T18:30:00Z",
-            "duration": 314
+            "episodeTitle": "Rita Ora on taking back her music and changing attitudes towards refugees",
+            "episodeId": "pyrlhwg",
+            "titleSlug": "rita-ora-on-taking-back-her-music-and-changing-attitudes-towards-refugees",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6GSoYepwN8zdjdlytYDjv3/70ae6ba4d5d35e97c1cb3bf97daebe11/RITA_ORA_5.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The singer-songwriter - who was born in Kosovo to Albanian parents - says there needs to be more focus on the positives immigration brings to Britain.",
+            "dateTime": "2023-07-14T19:06:00Z",
+            "duration": 253
           },
           {
             "imagePresets": {},
-            "episodeTitle": "The pioneering surgical robots which could be key to cutting NHS waiting times",
-            "episodeId": "cpbps53",
-            "titleSlug": "the-pioneering-surgical-robots-which-could-be-key-to-cutting-nhs-waiting-times",
-            "href": "the-pioneering-surgical-robots-which-could-be-key-to-cutting-nhs-waiting-times/cpbps53",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/WkYJaAkQRO27iwWTdBdQi/0740caab907e28aa1cf46b9af1770233/ROBOT_THUMB_FINAL.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "ITV News visits Guy's and St Thomas' hospital trust, which has seven robots in their operating theatres, carrying out up to 1,500 procedures a year.",
-            "dateTime": "2023-06-07T18:44:00Z",
-            "duration": 292
+            "episodeTitle": "Traditional Chinese Medicine: Why are some people skeptical?",
+            "episodeId": "t7k2g60",
+            "titleSlug": "traditional-chinese-medicine-why-are-some-people-skeptical",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7FLeVtbWile1ABabmUURPh/e30162265001c4d7689079afae1e62e8/lack_of_science.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Dating back two thousand years traditional Chinese medicine is proving more and more popular, but concerns over a lack of scientific evidence are growing.",
+            "dateTime": "2023-07-13T18:26:00Z",
+            "duration": 263
           },
           {
             "imagePresets": {},
-            "episodeTitle": "The U.S. city with a murder rate 20 times the national average",
-            "episodeId": "1gjwbqh",
-            "titleSlug": "the-us-city-with-a-murder-rate-20-times-the-national-average",
-            "href": "the-us-city-with-a-murder-rate-20-times-the-national-average/1gjwbqh",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/59hO2lzMVacF4hYY362I4P/6a64d271f3b019113a2bdf62e813c67f/THUMB_FOR_GIN_VIOLENCE_FINAL.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "New figures show there have been 70 murders so far in St.Louis this year - predominantly from gun crime. Dan Rivers visits the streets of this dangerous city.",
-            "dateTime": "2023-06-06T21:15:00Z",
-            "duration": 421
+            "episodeTitle": "Calls for Monkey Dust to be made a Class A drug - but what is it?",
+            "episodeId": "lv9nysc",
+            "titleSlug": "calls-for-monkey-dust-to-be-made-a-class-a-drug-but-what-is-it",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/eQRkN3t1u9u0MzShWVlbp/f70a8f6488cf07d1ac0318b7aa52e840/monkey_dust_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The drug is being linked to violence and unpredictable behaviour, piling pressure on emergency services, and one of the worst areas is Stoke-on-Trent.",
+            "dateTime": "2023-07-12T18:15:00Z",
+            "duration": 307
           },
           {
             "imagePresets": {},
-            "episodeTitle": "The fears and frustration facing many of the UK's elderly carers",
-            "episodeId": "qgpz8x7",
-            "titleSlug": "the-fears-and-frustration-facing-many-of-the-uks-elderly-carers",
-            "href": "the-fears-and-frustration-facing-many-of-the-uks-elderly-carers/qgpz8x7",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1QWKctj95bmYz7uoiojS4w/d95de9a2f90688cff25919e3964ac0d5/social_care_thumb_white_border.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "ITV News speaks to 79-year-old Jessie, a full-time carer of her disabled son Andrew. She says she's frightened about what will happen to him when she dies.",
-            "dateTime": "2023-06-05T18:15:00Z",
-            "duration": 373
+            "episodeTitle": "Almost half of English hospitals forced to temporarily close services due to disrepair ",
+            "episodeId": "zzlbsyf",
+            "titleSlug": "almost-half-of-english-hospitals-forced-to-temporarily-close-services-due-to-disrepair",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3HBF371W93xrPT2b0DtlO2/a30cb4dbca3f82f2e652c9496ff52416/HOSPIATLS_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "ITV News has found that some buildings are so structurally unsafe that entire departments - including A&E and maternity units - have had to shut for good.",
+            "dateTime": "2023-07-11T20:31:00Z",
+            "duration": 430
           },
           {
             "imagePresets": {},
-            "episodeTitle": "'An attempt to smear the LGBT community': The battle over Tennessee's 'drag ban'",
-            "episodeId": "7067vdd",
-            "titleSlug": "an-attempt-to-smear-the-lgbt-community-the-battle-over-tennessees-drag-ban",
-            "href": "an-attempt-to-smear-the-lgbt-community-the-battle-over-tennessees-drag-ban/7067vdd",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1ms1qkpcn36mLFfzE4xVQj/4a1934dc9d382a73825a359632810a4d/drag_tn.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Campaigners are trying to block a new law in Tennessee, which bans drag performances anywhere a child might see them. Dan Rivers reports for 'On Assignment'.",
-            "dateTime": "2023-06-01T09:35:00Z",
-            "duration": 602
+            "episodeTitle": "Sobering warning issued about the hidden dangers of Ketamine drug ",
+            "episodeId": "4p7zsm6",
+            "titleSlug": "sobering-warning-issued-about-the-hidden-dangers-of-ketamine-drug",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2T0xWHBtvuSrMG03HbxyMb/f2292f93f3f20ddc65ff59eaff708c31/KETAMINE_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "A drugs recovery centre in Wales has told ITV News there has been an increase in young people being admitted with bladder failure after taking the drug.",
+            "dateTime": "2023-07-10T18:25:00Z",
+            "duration": 301
           },
           {
             "imagePresets": {},
-            "episodeTitle": "John Cleese says phone hacking experience left him feeling 'slightly violated'",
-            "episodeId": "2nmhp2c",
-            "titleSlug": "john-cleese-says-phone-hacking-experience-left-him-feeling-slightly-violated",
-            "href": "john-cleese-says-phone-hacking-experience-left-him-feeling-slightly-violated/2nmhp2c",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1cdCp6gYTIno5EmEz9aFRF/7020c0341948b38d305b2753b71bda7d/ITVX_JOHN_CLEESE.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The Fawlty Towers star spoke to ITV News as he attended London's High Court, for the high profile hacking case against Mirror Group Newspapers.",
-            "dateTime": "2023-05-26T21:57:00Z",
-            "duration": 175
+            "episodeTitle": "Family of Olivia Pratt-Korbel backing petition to make killers face victims",
+            "episodeId": "4z08nm7",
+            "titleSlug": "family-of-olivia-pratt-korbel-backing-petition-to-make-killers-face-victims",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5L6huccCUy6UIDRmVTlPmD/8bc5fe7a5de2ba25be31944ea300b4be/ITVX_THUMB_OLIVIA_CAMPAIGN_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The family of murdered schoolgirl Olivia Pratt-Korbel are petitioning to make killers attend sentencing hearings, after Thomas Cashman chose not to attend his.",
+            "dateTime": "2023-07-10T18:18:00Z",
+            "duration": 178
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Worrying levels of E. coli found inside some UK oysters",
-            "episodeId": "fcd41z2",
-            "titleSlug": "worrying-levels-of-e-coli-found-inside-some-uk-oysters",
-            "href": "worrying-levels-of-e-coli-found-inside-some-uk-oysters/fcd41z2",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/26VsEbim7VmngdM8VKiKBa/4e4315690b174189b68e0909a4abbb2c/ECOLI_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Exclusive research carried out by ITV News and Watershed Investigations found some shellfish areas have seven times the E. coli levels deemed safe for eating.",
-            "dateTime": "2023-05-26T18:00:00Z",
+            "episodeTitle": "'You never get closure': Olivia Pratt-Korbel's mum calls for change to sentencing rules",
+            "episodeId": "mxxfms9",
+            "titleSlug": "you-never-get-closure-olivia-pratt-korbels-mum-calls-for-change-to-sentencing-rules",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3U42bErKitt64Cxu1ZBuSY/020fe5136a0df16aba0416aa0b23ab0f/olivia.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "In her first TV interview, Cheryl Korbel said she wants a change in the law to force criminals to face victims' families when they are sentenced.",
+            "dateTime": "2023-07-07T17:47:00Z",
+            "duration": 407
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Boom in holiday homes forcing locals out of tourist hotspots",
+            "episodeId": "g2hym5z",
+            "titleSlug": "boom-in-holiday-homes-forcing-locals-out-of-tourist-hotspots",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/60LMkStdRsLyj7dma1oDhp/dfbec558f7e2cb63d8abfa89cd3feaef/AIR_BNB_THUMB_PR.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "An ITV News investigation has found that in some areas the number of Air BnB lets has increased by 76% since the pandemic.",
+            "dateTime": "2023-07-07T18:15:00Z",
+            "duration": 330
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Extreme and protracted drought threatens way of life in southern Spain",
+            "episodeId": "5qn93sq",
+            "titleSlug": "extreme-and-protracted-drought-threatens-way-of-life-in-southern-spain",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4isPOTAa6TD4yjyYj61zWz/30fe18065e46995f6df493f02c9e10a0/SPAIN_DROUGHT_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Campaigners have warned that the way products like mangoes and avocadoes are farmed - many of them for export to the UK - will have to change.",
+            "dateTime": "2023-07-06T18:15:00Z",
+            "duration": 309
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "How is Western military support bolstering Ukraine's counteroffensive?",
+            "episodeId": "jfqkb1n",
+            "titleSlug": "how-is-western-military-support-bolstering-ukraines-counteroffensive",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7BDxATj0cdm16DRrd64pQ3/a9df2a2bbc5591e4eeab3d220186f358/UKRAINE_THUMB_STRAPS_2.png?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "John Irvine visited Ukrainian soldiers last year, as they called for greater support. He's now returned to the same unit to see the impact Western aid has had.",
+            "dateTime": "2023-07-05T21:30:00Z",
+            "duration": 221
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Increased pressure to ban puppy yoga over animal welfare concerns",
+            "episodeId": "cf07g29",
+            "titleSlug": "increased-pressure-to-ban-puppy-yoga-over-animal-welfare-concerns",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3zlnf4nvhjH9A5RLtk5Amp/a45c5f400c53bddbb03e1a8a82487214/PUPPY_YOGA_THUMB_V4.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "There are have been further calls to ban Puppy Yoga after an ITV News investigation into the growing trend.",
+            "dateTime": "2023-07-04T21:24:00Z",
+            "duration": 173
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "The low rates of conviction for abuse in care homes, despite secret filming",
+            "episodeId": "4x9vrfj",
+            "titleSlug": "the-low-rates-of-conviction-for-abuse-in-care-homes-despite-secret-filming",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6zVmgtlRxc8CCfkfZvOc7O/b13f858e2c1bed4f43b4526271d1dec9/labelled_thumb_care_home.png?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "ITV News research found that only 1.4% of care home abuse allegations made in England and Wales resulted in charges.",
+            "dateTime": "2023-06-30T21:15:00Z",
             "duration": 279
           },
           {
             "imagePresets": {},
-            "episodeTitle": "The chaos and confusion caused by the ever-expanding power of A.I",
-            "episodeId": "8sdkmv7",
-            "titleSlug": "the-chaos-and-confusion-caused-by-the-ever-expanding-power-of-ai",
-            "href": "the-chaos-and-confusion-caused-by-the-ever-expanding-power-of-ai/8sdkmv7",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/35TL7N5nvPlcD56XeU41Wk/7610e438dd58c0f3efce7ea92115069c/AI_THUMB_PR.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "An ITV News documentary has been exploring the risks posed by artificial intelligence, such as its power to undermine democracy or impersonate individuals.",
-            "dateTime": "2023-05-25T12:15:51.23Z",
-            "duration": 257
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "Fresh claims of misogyny and bullying behaviour within Metropolitan Police",
-            "episodeId": "c096zvf",
-            "titleSlug": "fresh-claims-of-misogyny-and-bullying-behaviour-within-metropolitan-police",
-            "href": "fresh-claims-of-misogyny-and-bullying-behaviour-within-metropolitan-police/c096zvf",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5H9891QUZGb7o1yTP9UO0S/789d3d0bde98777fd78d40d1cfe2a01a/POLICE7.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "A former detective within the Met has given an inside account of her time in the force. Jess McDonald\u2019s book 'No Comment' is out on Thursday, May 25.",
-            "dateTime": "2023-05-24T18:22:00Z",
-            "duration": 318
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "Bludgeoned from behind: Survivor of alleged Levi Bellfield attack speaks out",
-            "episodeId": "0zjspjy",
-            "titleSlug": "bludgeoned-from-behind-survivor-of-alleged-levi-bellfield-attack-speaks-out",
-            "href": "bludgeoned-from-behind-survivor-of-alleged-levi-bellfield-attack-speaks-out/0zjspjy",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7AX1sDSuoh6H5c4uxYDaL6/57163f42c47641207ce10cb34652cd31/BELLFIELD_EXC.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "A woman who believes she was attacked by Millie Dowler's killer Levi Bellfield has told ITV News how police failed to tell her of his alleged confession.",
-            "dateTime": "2023-05-22T18:32:00Z",
-            "duration": 346
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "Exclusive figures reveal a third of children being exposed to vape adverts online",
-            "episodeId": "7y97qwy",
-            "titleSlug": "exclusive-figures-reveal-a-third-of-children-being-exposed-to-vape-adverts-online",
-            "href": "exclusive-figures-reveal-a-third-of-children-being-exposed-to-vape-adverts-online/7y97qwy",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1VYwidUORwBdb3VEYAVTMe/bce19b92ae9aa206742bae50962c9c76/vaping_7pm.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The Advertising Standards Authority say they are increasingly concerned about e-cigarette promotions targeting young people online.",
-            "dateTime": "2023-05-17T18:34:00Z",
-            "duration": 369
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "How a group of volunteer British doctors are helping to save lives in Syria",
-            "episodeId": "8sgkd0n",
-            "titleSlug": "how-a-group-of-volunteer-british-doctors-are-helping-to-save-lives-in-syria",
-            "href": "how-a-group-of-volunteer-british-doctors-are-helping-to-save-lives-in-syria/8sgkd0n",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4w5KULqY7kfxn0KYVAobOF/659420618236b07032049495d97d5ac6/7PM_SYRIA_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The doctors from the UK are training and supporting local medics still dealing with the aftermath of February's devastating earthquakes.",
-            "dateTime": "2023-05-16T21:40:00Z",
-            "duration": 260
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "The people pushed to their limits by the cost of living crisis",
-            "episodeId": "77yys1f",
-            "titleSlug": "the-people-pushed-to-their-limits-by-the-cost-of-living-crisis",
-            "href": "the-people-pushed-to-their-limits-by-the-cost-of-living-crisis/77yys1f",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4sFxue6JSJxGKmNHn1cPiy/eaeda32022e702b88904e11354427328/HEWITT_DOCO_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Watch 'Life & Debt: Stories from the Edge', an ITV News documentary looking at the true impact the squeeze in living standards is having on people in the UK.",
-            "dateTime": "2023-05-01T16:53:07.416Z",
-            "duration": 2826
+            "episodeTitle": "Wagner Group was close to agreeing lucrative deal with President Bashar al-Assad",
+            "episodeId": "z257v1w",
+            "titleSlug": "wagner-group-was-close-to-agreeing-lucrative-deal-with-president-bashar-al-assad",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/63ITNn6RnVb7cMlY1q9tyt/19fd94d2b064cb550227fad1969e2b02/wagner_6.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "In an exclusive report, ITV News' Security Editor Rohit Kachroo uncovers negotiations that were taking place between the Russian group and the Syrian president.",
+            "dateTime": "2023-06-29T21:37:00Z",
+            "duration": 268
           }
         ]
       },
@@ -845,135 +862,258 @@
         "clips": [
           {
             "imagePresets": {},
-            "episodeTitle": "Hayfever feeling worse than ever? Why some people are blaming male trees ",
-            "episodeId": "1cp8b09",
-            "titleSlug": "hayfever-feeling-worse-than-ever-why-some-people-are-blaming-male-trees",
-            "href": "hayfever-feeling-worse-than-ever-why-some-people-are-blaming-male-trees/1cp8b09",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5VEL6EuG2waH9plYfi0537/ed9e69e717687ba89a185121bc30403f/HAYFEVER_TN.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "You may have heard that symptoms in urban areas have been amplified by the planting of 'male trees' - but could there be any truth to these claims? ",
-            "dateTime": "2023-06-09T03:00:00Z",
-            "duration": 139
+            "episodeTitle": "Women's World Cup: Teams to watch, Lionesses to look out for and that pay controversy",
+            "episodeId": "32hjld0",
+            "titleSlug": "womens-world-cup-teams-to-watch-lionesses-to-look-out-for-and-that-pay-controversy",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4Sy7QXwKeibCU2Dwsdkms/e1e5856fef875f976bf9f48936ed4cb3/football_new_thumb.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "ITV News' Sports Editor Steve Scott with his best predictions on the players and teams who could steal the limelight at the Women's World Cup.",
+            "dateTime": "2023-07-19T12:20:00Z",
+            "duration": 496
           },
           {
             "imagePresets": {},
-            "episodeTitle": "What were the key moments from Prince Harry's time on the stand?",
-            "episodeId": "0z625kw",
-            "titleSlug": "what-were-the-key-moments-from-prince-harrys-time-on-the-stand",
-            "href": "what-were-the-key-moments-from-prince-harrys-time-on-the-stand/0z625kw",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7H4CzYo9xhGuMsZgOf291H/8d91fa1b2b9c3e7d8387d6d9354e0df7/EXPLAINER_THUMB_FINAL.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "After two days of giving evidence at the High Court in his case against Mirror Group Newspapers, ITV News examines what we have learnt from Harry's testimony.",
-            "dateTime": "2023-06-07T19:19:00Z",
+            "episodeTitle": "What does the heatwave in Europe mean for UK travellers going to 'hot spots'?",
+            "episodeId": "r0q2d2c",
+            "titleSlug": "what-does-the-heatwave-in-europe-mean-for-uk-travellers-going-to-hot-spots",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1MVTEn3R66nas9v6dMeHSe/a06122aaf556a4fd9ab5f5c947734a1a/heatwave.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Record-breaking heat has been forecast around the world this week. So what can you do to protect yourself? And what are your rights as a consumer?",
+            "dateTime": "2023-07-17T13:45:00Z",
             "duration": 168
           },
           {
             "imagePresets": {},
-            "episodeTitle": "What could the consequences be of the Ukraine dam attack?",
-            "episodeId": "l2br9n1",
-            "titleSlug": "what-could-the-consequences-be-of-the-ukraine-dam-attack",
-            "href": "what-could-the-consequences-be-of-the-ukraine-dam-attack/l2br9n1",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3ljlwul8KTdFP3JYjnF4mQ/3d1085b60418677e36b699d8c88d3061/dam_wall_tn.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "The collapse of the Kakhovka dam is likely to have far-reaching and long-lasting effects on the southern region of Ukraine and beyond.",
-            "dateTime": "2023-06-07T18:45:00Z",
-            "duration": 153
+            "episodeTitle": "Hollywood strikes: Why are people walking out and what do they want?",
+            "episodeId": "vrnn0bw",
+            "titleSlug": "hollywood-strikes-why-are-people-walking-out-and-what-do-they-want",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4i0jsIcYEl5at3RALtQyGa/0ff0e1411b10bb63699bb604d32ca813/hollywood_4.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Hollywood actors have gone on strike, bringing TV and film productions to a halt. But why, in an industry of wealth and glamour, are they taking action?",
+            "dateTime": "2023-07-14T19:25:00Z",
+            "duration": 133
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Duke of Sussex V Mirror Group Newspapers: What is the trial about?",
-            "episodeId": "qn01pp5",
-            "titleSlug": "duke-of-sussex-v-mirror-group-newspapers-what-is-the-trial-about",
-            "href": "duke-of-sussex-v-mirror-group-newspapers-what-is-the-trial-about/qn01pp5",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4fxrFDvjVuMeU4lJIHMke4/4307c758c18ca28cc3633c2d07fb3d06/harry_thumb_final_explainer.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Prince Harry will be cross-examined in the High Court this week as he gives evidence in his legal action against Mirror Group Newspapers.",
-            "dateTime": "2023-06-06T05:09:00Z",
-            "duration": 146
+            "episodeTitle": "Security scares and a 'forgotten passcode': What's going on with Boris Johnson's phone?",
+            "episodeId": "gfzx4qy",
+            "titleSlug": "security-scares-and-a-forgotten-passcode-whats-going-on-with-boris-johnsons-phone",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1RVck8TXd8eyRqmR0AcEQf/417f4fc262bc80c71c69e20297229ce5/EPXLAINER_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Why the former Prime Minister's old iPhone is back in the news, just a week after the High Court ruled that his messages must be handed to the Covid inquiry.",
+            "dateTime": "2023-07-13T20:49:00Z",
+            "duration": 125
           },
           {
             "imagePresets": {},
-            "episodeTitle": "Covid-19 Inquiry: Why is the government taking legal action?",
-            "episodeId": "chmjddl",
-            "titleSlug": "covid-19-inquiry-why-is-the-government-taking-legal-action",
-            "href": "covid-19-inquiry-why-is-the-government-taking-legal-action/chmjddl",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2JMhxPKo1ydhBqd1BbN4LF/a25ac62e44e2e5fde09910deb09c197d/covid_inquiry_explainer.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "A preliminary hearing of the Covid Inquiry is underway, with the chair addressing the government's planned legal action over the release of material.",
-            "dateTime": "2023-06-06T09:46:00Z",
-            "duration": 122
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "Heat health Alert Service: What is it and how will it work?",
-            "episodeId": "43sy6sn",
-            "titleSlug": "heat-health-alert-service-what-is-it-and-how-will-it-work",
-            "href": "heat-health-alert-service-what-is-it-and-how-will-it-work/43sy6sn",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/39hq8JvacHQ8cBJtbucWDF/21cec4924fc1adf339dd0521cdb00996/heat_explainer_v22.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "As the first heat health alert of the year comes into force today, we explain what the new weather alert system aims to do.",
-            "dateTime": "2023-06-09T05:16:00Z",
-            "duration": 105
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "How seriously should we take warnings that AI could lead to our extinction?",
-            "episodeId": "0h61ytq",
-            "titleSlug": "how-seriously-should-we-take-warnings-that-ai-could-lead-to-our-extinction",
-            "href": "how-seriously-should-we-take-warnings-that-ai-could-lead-to-our-extinction/0h61ytq",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4D66rxhPfyUWeuqY51nAg9/e7061e43bf969c51800d5bf9ad2f4cae/AI_EXTINCTION_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Experts have warned that mitigating the risk of 'extinction' should be a global priority on the same level as pandemics and wars. ",
-            "dateTime": "2023-05-31T19:55:00Z",
-            "duration": 150
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "Women's World Cup: What you need to know ahead of the tournament",
-            "episodeId": "hzb4lml",
-            "titleSlug": "womens-world-cup-what-you-need-to-know-ahead-of-the-tournament",
-            "href": "womens-world-cup-what-you-need-to-know-ahead-of-the-tournament/hzb4lml",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5BqSZcyn8ZfX8lDz5051HG/e3460b194e093b89788ae49c25787d9c/WOMEN-S_WORLD_CUP_THUMB_V3.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "As Sarina Wiegman announces her squad for the summer World Cup, what else do we know about the competition?",
-            "dateTime": "2023-05-31T19:58:00Z",
-            "duration": 103
-          },
-          {
-            "imagePresets": {},
-            "episodeTitle": "Another rail operator to ban electric scooters - where and why?",
-            "episodeId": "6sh0735",
-            "titleSlug": "another-rail-operator-to-ban-electric-scooters-where-and-why",
-            "href": "another-rail-operator-to-ban-electric-scooters-where-and-why/6sh0735",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5FeliEM9KBWt9oHaV1ZFyw/1b29fdbc1414e0ce76ec1e78411a8762/new_scooter_thumb.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "South Western Railway is joining rail operator Great Western Railway, Transport for London and Nexus in banning e-scooters across the country.",
-            "dateTime": "2023-05-31T10:55:00Z",
+            "episodeTitle": "Which airports have hiked up drop-off charges, and how can you avoid them?",
+            "episodeId": "hfx6k9j",
+            "titleSlug": "which-airports-have-hiked-up-drop-off-charges-and-how-can-you-avoid-them",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5gIWERhcIgSKw9FxoYYYoW/b00f70b883f552c0206211f06b961850/AIRPORTS_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "More than a third of major UK airports have increased their 'kiss and fly' fees for drivers dropping people off near departure areas, according to the RAC.",
+            "dateTime": "2023-07-13T15:54:00Z",
             "duration": 120
           },
           {
             "imagePresets": {},
-            "episodeTitle": "What are the key events in the disappearance of Madeleine McCann?",
-            "episodeId": "ddqrmlt",
-            "titleSlug": "what-are-the-key-events-in-the-disappearance-of-madeleine-mccann",
-            "href": "what-are-the-key-events-in-the-disappearance-of-madeleine-mccann/ddqrmlt",
-            "imageUrl": "https://assets.ctfassets.net/go68aep20o4s/3W1X9APOXOiuRRX6cVClUd/68b18beaabb658b8f0f912b7adb29df5/FINAL_THUMB_MADDIE.bmp?w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
-            "synopsis": "In the week police divers searched a dam in Portugal, we look back at the 16 year long investigation into the disappearance of three-year-old Madeleine McCann.",
-            "dateTime": "2023-05-27T03:00:00Z",
+            "episodeTitle": "Lucy Letby trial: What is the nurse accused of and what has been the key evidence?",
+            "episodeId": "wy7byk2",
+            "titleSlug": "lucy-letby-trial-what-is-the-nurse-accused-of-and-what-has-been-the-key-evidence",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1Ew86XEAgEP6Z2YimqjsEg/6642f31eff0496f3c7baedd1b4a598dc/LETBY_THUMB_V2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The jury's begun deliberating in the trial of Lucy Letby, charged with the murders of seven babies and attempted murders of ten others. She denies all charges.",
+            "dateTime": "2023-07-10T12:15:00Z",
+            "duration": 162
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "BBC presenter allegations: The corporation lays out its timeline of events",
+            "episodeId": "mhsz1z4",
+            "titleSlug": "bbc-presenter-allegations-the-corporation-lays-out-its-timeline-of-events",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/677FiONOpDkbgi7YStmFcm/d30f0c76251fd2b591007afcf5a53f04/FINISHED_CHARLIE_EXPLAINER_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "With claims and counter-claims about the behaviour of a BBC presenter being discussed, here is what we know so far from the BBC.",
+            "dateTime": "2023-07-11T20:16:58.526Z",
+            "duration": 142
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Summer travel chaos: What do looming air traffic control strikes mean for people hoping to get away?",
+            "episodeId": "6h8jbym",
+            "titleSlug": "summer-travel-chaos-what-do-looming-air-traffic-control-strikes-mean-for-people-hoping-to-get-away",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7g0a5SU10ABn2KXs8qZ6Wv/32441f5146de1f2c857364f0f6ec1f79/travel_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Travel expert Paul Charles on how to cover yourself this summer as air traffic control staff threaten to cause major disruption to flights across the continent.",
+            "dateTime": "2023-07-07T16:32:00Z",
+            "duration": 430
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "How to protect against skin cancer, as cases hit a record high",
+            "episodeId": "2w2tsvt",
+            "titleSlug": "how-to-protect-against-skin-cancer-as-cases-hit-a-record-high",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3XXfmBqlCohh6Ww6xwkR6p/e4b0fada8a86ab178bad2e6085b6f09e/skin_cancer_expl.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The number of serious skin cancer cases among the over-55s has gone up by 195% since the 1990s, so what can we do to prevent it?",
+            "dateTime": "2023-07-06T23:20:00Z",
+            "duration": 143
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Survey reveals that over a quarter of Brits have never boiled an egg",
+            "episodeId": "l5hlgth",
+            "titleSlug": "survey-reveals-that-over-a-quarter-of-brits-have-never-boiled-an-egg",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4R6soMSX1gAMHqlGtTbCdo/a878296d36b7a54e221dd8997343de63/FOOD_SURVEY_THUMB_PR.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "A survey of 4,000 adults found a higher number of people than might be expected are not comfortable with simple culinary skills.",
+            "dateTime": "2023-07-06T19:37:33.537Z",
+            "duration": 118
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Forest Green Rovers men's manager joins list of female trailblazers ",
+            "episodeId": "3sxbgrm",
+            "titleSlug": "forest-green-rovers-mens-manager-joins-list-of-female-trailblazers",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/72Y0hlD5rC7v2AqK6NrGSt/250b0568edb0ca2abb8ef4dfd5803da1/FEMALE_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "As Hannah Dingley is appointed caretaker manager of Forest Green Rovers men's team, we look at the other woman who reached new heights in their field.",
+            "dateTime": "2023-07-05T21:32:51.845Z",
+            "duration": 182
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "75 years of the NHS: A look back at its trials and triumphs",
+            "episodeId": "t81n2bj",
+            "titleSlug": "75-years-of-the-nhs-a-look-back-at-its-trials-and-triumphs",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3DqfBBvgq5Z4OOeDUMDhPa/4de60ac1689ae8431b88a3a789c7c9b8/nhs_explainer.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Since its launch in 1948 the NHS has touched the lives of millions, with over half the population saying it's what makes them most proud to be British. ",
+            "dateTime": "2023-07-04T17:03:22.395Z",
+            "duration": 180
+          }
+        ]
+      },
+      {
+        "title": "All Around The UK",
+        "clips": [
+          {
+            "imagePresets": {},
+            "episodeTitle": "Wendy's fast food restaurant changes sign after schoolgirl spots mistake",
+            "episodeId": "2mbxpjb",
+            "titleSlug": "wendys-fast-food-restaurant-changes-sign-after-schoolgirl-spots-mistake",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2O7oCv4SYEYW99wFnd3Lat/f42b7d76b747c4227ba5ebbb397ab8ef/wendys_thumb_straos.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Nepheli, a pupil at Hayes Park School in Uxbridge, wrote to the restaurant after she noticed the apostrophe in 'Wendy's' was missing.",
+            "dateTime": "2023-07-20T20:15:00Z",
+            "duration": 135
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Looking for Summer bike ride inspiration? Cycling the Viking Coastal trail",
+            "episodeId": "4gj8c7r",
+            "titleSlug": "looking-for-summer-bike-ride-inspiration-cycling-the-viking-coastal-trail",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5AYlhEPKiFJ3FyD2J7beXB/b5dd5b949aaaa863f89a8ac90f1e2448/cycling_thumb_strps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "More people are being encouraged to cycle rather than drive. Summer, then, is the perfect time to dust off your bike and discover the best routes.",
+            "dateTime": "2023-07-19T19:37:00Z",
+            "duration": 251
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Community comes together to harvest huge lavender field",
+            "episodeId": "krk8n0f",
+            "titleSlug": "community-comes-together-to-harvest-huge-lavender-field",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/49y94f9mFtwQ5PqenVT86l/4e4dc15aadcf472a192ced4f9aede37c/lavendar_straps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Julia Dimmock has 5,000 lavender bushes at Finchingfield in Essex. This year the crop is so good that she's asked for local volunteers to help her get it in.",
+            "dateTime": "2023-07-17T21:30:00Z",
+            "duration": 194
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Breakthrough in Ash Dieback research could provide answers to UK's biggest tree disease",
+            "episodeId": "k5d7pyr",
+            "titleSlug": "breakthrough-in-ash-dieback-research-could-provide-answers-to-uks-biggest-tree-disease",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/21On2g49khyngvnaerwz5B/296e51cd577975807023fe86ac1f9ce7/ash_dieback_thumb_straps.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Thousands of trees have been cut down due to Ash Dieback, with predictions 160 million could be lost across the country. Now a breakthrough could provide hope.",
+            "dateTime": "2023-07-15T16:30:16.081Z",
+            "duration": 267
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Prince and Princess of Wales make family outing to the Royal Air Tattoo",
+            "episodeId": "hr6qw8y",
+            "titleSlug": "prince-and-princess-of-wales-make-family-outing-to-the-royal-air-tattoo",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5QOG8IVEgXkoURUOcyLDYp/852b9b0d9750d7a18233de8e25db70ce/ROYALS_THUMB_STRAPS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "The royal couple took all three of the children to the event at RAF Fairford in Gloucestershire, where they met officials and toured aircraft.",
+            "dateTime": "2023-07-14T18:02:00Z",
+            "duration": 115
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Police given bravery award for heroic attempt to save boys in Solihull lake incident",
+            "episodeId": "vv2hc8y",
+            "titleSlug": "police-given-bravery-award-for-heroic-attempt-to-save-boys-in-solihull-lake-incident",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3QzV2uq1JQiqcVL1Tx2lbO/ec13716206764a27bde23ceff67b15b4/BRAVERY_STRAP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Police officers used their batons and fists to break the ice to try to save the children. An inquest found the incident was an 'awful, terrible accident'.",
+            "dateTime": "2023-07-14T18:15:00Z",
+            "duration": 170
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "'Adopt a Grandparent' bringing together the young and the old",
+            "episodeId": "x3dh3yn",
+            "titleSlug": "adopt-a-grandparent-bringing-together-the-young-and-the-old",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/71swxNPz1HIbvu4SODwWKM/9fd278d5fd38f41430611a8d492a3607/grandparent_scheme.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "200,000 older people haven't had a conversation with a friend or relative in over a month, a sad reality which inspired one care home resident to try and help. ",
+            "dateTime": "2023-07-13T21:13:00Z",
+            "duration": 173
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Why a photographer from Bath has been snapping selfies at the barbers for half a century",
+            "episodeId": "nw1tn5y",
+            "titleSlug": "why-a-photographer-from-bath-has-been-snapping-selfies-at-the-barbers-for-half-a-century",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1GoCaIRvONcSEAAg7nsdbH/aa72a679976a54c9b98207af72026845/50_years_of_selfie_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Sam Farr has been capturing 'mirror portraits' with his hairdresser Joe for the past five decades, but there's more to it for him than just a fresh cut.",
+            "dateTime": "2023-07-12T20:21:00Z",
+            "duration": 165
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Why aren't tourists heading to Wales in the same numbers as elsewhere in the UK?",
+            "episodeId": "cc64y5x",
+            "titleSlug": "why-arent-tourists-heading-to-wales-in-the-same-numbers-as-elsewhere-in-the-uk",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6GvWt0ETPbmcFy73mZrl8P/bcfb59c9e806f2e2180afafbbc1a8f0c/WALES_2.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Wales' tourism board say the country is \"like no other\", with its rich history and proud culture, but transport links are being blamed for putting visitors off.",
+            "dateTime": "2023-07-12T18:22:00Z",
+            "duration": 162
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Save the swifts: Calls to build a better future for Britain's birdlife in our housing",
+            "episodeId": "6y9mrsv",
+            "titleSlug": "save-the-swifts-calls-to-build-a-better-future-for-britains-birdlife-in-our-housing",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/el4ZRISl6psLd99iCDXML/422c79aaf51fd0a38c5e2b3e1424507b/BIRDS_1.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Campaigners are calling for it to be compulsory for all new-build houses to make room for nests of swifts following a decline in the species.",
+            "dateTime": "2023-07-10T21:46:00Z",
+            "duration": 148
+          },
+          {
+            "imagePresets": {},
+            "episodeTitle": "Could a player from Northern Ireland make it to centre court at Wimbledon?",
+            "episodeId": "s9yt9n4",
+            "titleSlug": "could-a-player-from-northern-ireland-make-it-to-centre-court-at-wimbledon",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2heaIcr7P2MCYqrVDp1NP9/28b792f5f624e029cfa322c834f15f0b/WIMBELDON.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "This year marks the 136th Wimbledon Championship but only one Belfast player has served her way to the competition to date.",
+            "dateTime": "2023-07-11T06:29:00Z",
             "duration": 172
           },
           {
             "imagePresets": {},
-            "episodeTitle": "The top four scams to be on the lookout for",
-            "episodeId": "fm43jn2",
-            "titleSlug": "the-top-four-scams-to-be-on-the-lookout-for",
-            "href": "the-top-four-scams-to-be-on-the-lookout-for/fm43jn2",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/47LO9i1P8tiufXY6SrxLCy/e106c820bc48dddd0f97bbbb09d6e416/scams_thumbnail.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "Online scams are on the rise - from suspicious links in emails, to adverts for investment opportunities on social media. Here's what to look out for.",
-            "dateTime": "2023-05-22T20:42:00Z",
-            "duration": 120
+            "episodeTitle": "Hundreds waiting to board the Boeing 737 converted to a Hampshire holiday let",
+            "episodeId": "0ttym3j",
+            "titleSlug": "hundreds-waiting-to-board-the-boeing-737-converted-to-a-hampshire-holiday-let",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4ahvd3Jwr6J3spkOspDxUg/00e5987708eeaf3d55c4d07f2ea8380b/plane_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "There is a two-year wait for holidaymakers to spend a night in a 1960s aircraft in entrepreneur Steven Northam's back garden near Winchester.",
+            "dateTime": "2023-07-07T21:07:00Z",
+            "duration": 161
           },
           {
             "imagePresets": {},
-            "episodeTitle": "What has the human and financial cost of climate change been?",
-            "episodeId": "ybjsxbw",
-            "titleSlug": "what-has-the-human-and-financial-cost-of-climate-change-been",
-            "href": "what-has-the-human-and-financial-cost-of-climate-change-been/ybjsxbw",
-            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2Rf8nNCRa2mmCur1iThxEQ/41ac9b53877d32ec0f74597f123c73fc/CLIMATE_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-            "synopsis": "New statistics show the extent of damage climate change is already causing. From floods in Italy to wildfires in Canada, we explain the results.",
-            "dateTime": "2023-05-22T16:54:00Z",
-            "duration": 128
+            "episodeTitle": "Abseils and German paint: The challenges of keeping the Westbury White Horse gleaming",
+            "episodeId": "nn87s4m",
+            "titleSlug": "abseils-and-german-paint-the-challenges-of-keeping-the-westbury-white-horse-gleaming",
+            "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2mKm9dYHFfay47Lq9aZlOT/a61888d573282a755e98ff45b39eb5d4/WESTBURY_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+            "synopsis": "Specialist cleaners have descended on the iconic Wiltshire landmark for an eight-week spring clean, with a number of logistical hurdles along the way.",
+            "dateTime": "2023-07-06T21:22:00Z",
+            "duration": 148
           }
         ]
       }

--- a/test/test_docs/html/index-data.json
+++ b/test/test_docs/html/index-data.json
@@ -115,7 +115,8 @@
       "ctaLabel": "Watch Now",
       "contentInfo": []
     },
-    {"imagePresets": {},
+    {
+      "imagePresets": {},
       "contentType": "film",
       "title": "Coyote Ugly",
       "tagName": null,
@@ -123,14 +124,29 @@
       "isPaid": false,
       "ccid": "nch31g7",
       "programmeId": "17523",
-      "encodedProgrammeId": {"letterA": "17523", "underscore": "17523"},
+      "encodedProgrammeId": {
+        "letterA": "17523",
+        "underscore": "17523"
+      },
       "description": "It’s time to get up & boogie on the bar in this irresistible comedy-drama",
       "productionYear": 2000,
       "dateTime": "2023-06-25T17:55:00Z",
       "duration": "2h",
       "ctaLabel": "Watch Film",
-      "genre": ["Films", "Comedy", "Romantic"],
-      "contentInfo": [["Films", "Comedy", "Romantic"], "2h", 2000]
+      "genre": [
+        "Films",
+        "Comedy",
+        "Romantic"
+      ],
+      "contentInfo": [
+        [
+          "Films",
+          "Comedy",
+          "Romantic"
+        ],
+        "2h",
+        2000
+      ]
     }
   ],
   "editorialSliders": {
@@ -11472,183 +11488,182 @@
       }
     }
   },
-  "newsShortformSliderContent": {
-    "header": {
-      "title": "",
-      "logo": {
-        "iconSrc": "<svg viewBox=\"0 0 300 56\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M7.25 14.388C2.768 14.388 0 11.205 0 7.194 0 3.184 2.767 0 7.25 0c4.484 0 7.255 3.183 7.255 7.194 0 4.01-2.767 7.194-7.254 7.194Zm29.7 34.807-.014.014c-4.451-3.878-6.528-9.35-6.528-15.208v1.397c0 4.523-.722 6.976-2.322 8.694-1.404 1.508-3.613 2.328-6.044 2.328-2.37 0-4.473-.791-5.725-2.113-1.31-1.382-1.918-3.298-1.918-6.13V20.444c0-.76-.29-1.117-1.147-1.117H1.221c-.846 0-1.125.332-1.125 1.124v16.014c0 6.392 1.649 10.055 4.525 12.92 3.74 3.739 10.139 5.411 16.204 5.411 6.057 0 12.372-2.143 16.11-5.587h.002l.014-.014Zm67.596-29.654c1.048.319 3.139.956 3.914 1.204.803.243 1.153.666 1.153 1.17 0 .499-.292 1.29-.691 2.367l-.016.044c-3.256 8.827-7.757 18.402-13.065 26.499-2.017 3.086-4.26 3.982-7.994 3.982-3.942 0-5.704-1.046-7.636-3.91-1.029-1.506-2.088-3.147-3.387-5.16-.363-.563-.745-1.155-1.15-1.78l-.003-.005c-4.17 6.818-11.31 10.83-21.024 10.83-7.36 0-14.023-2.256-17.693-5.597-4.451-3.879-6.529-9.358-6.529-15.216V8.186c0-1.328.347-2.249 1.097-2.933 1.108-1.006 3.38-1.497 6.062-1.497 2.682 0 4.961.491 6.062 1.497.743.684 1.097 1.597 1.097 2.933v11.148h11.323c.857 0 1.158.343 1.158 1.117v6.804c0 .759-.301 1.117-1.157 1.117h-6.37a12.604 12.604 0 0 1-4.954-.863v7.072c0 4.215.888 6.74 2.714 8.616 1.918 1.977 4.858 3.051 8.67 3.051 8.032 0 12.19-5.042 12.19-10.61 0-2.214-.646-4.017-1.935-6.227l-.032-.05c-1.154-1.967-1.465-2.801-1.465-3.911 0-3.277 5.8-6.786 9.713-6.786 1.395 0 2.29.34 3.238 1.457.391.48.746.989 1.062 1.522.96 1.563 2.556 4.366 4.374 7.556v.001c.89 1.561 1.831 3.215 2.777 4.862 1.865 3.245 3.868 6.847 4.955 8.917 3.312-5.68 7.024-14.8 9.462-22.918.244-.813.626-1.207 1.334-1.207.375 0 1.009.157 2.746.687ZM285.178 8.138c4.34 0 8.68.668 12.151 1.67l-.801 7.878c-3.271-.802-7.21-1.536-10.816-1.536-5.675 0-8.145 1.803-8.145 5.074 0 2.871 1.803 4.073 6.61 5.408l3.538 1.002c5.675 1.602 8.012 3.07 9.681 5.207 1.669 2.137 2.604 4.74 2.604 8.546 0 10.349-7.01 14.087-17.759 14.087-5.275 0-10.683-.934-13.887-1.936-1.069-.334-1.469-.734-1.469-1.87 0-1.134.334-3.004.734-4.406.401-1.402.868-1.736 1.469-1.736.267 0 .601.067 1.269.267 3.071.868 6.876 1.67 11.082 1.67 6.21 0 8.747-1.736 8.747-5.475 0-3.338-2.07-4.607-6.744-6.009l-4.473-1.335c-3.872-1.135-6.476-2.404-8.279-4.34-1.802-1.936-3.071-4.74-3.071-8.746 0-8.079 5.608-13.42 17.559-13.42ZM144.84 52.27l-16.891-30.178v31.046c0 1.335-.868 2.003-4.607 2.003-3.872 0-4.473-.668-4.473-2.07V8.806h11.283l19.095 34.183V8.806h9.08V52.27c0 2.203-2.604 2.737-6.209 2.737-4.474 0-6.276-.935-7.278-2.737Zm19.679-41.328c0-1.602.601-2.136 2.337-2.136h28.976v7.878h-21.565v10.75h18.427v7.81h-18.427v11.684h21.965v7.879h-29.376c-1.736 0-2.337-.534-2.337-2.137V10.942Zm75.184 41.127c.4 2.003 2.47 2.738 7.945 2.738 5.474 0 7.344-.534 7.945-2.738 3.204-12.284 6.743-27.974 9.48-43.263h-10.281c-2.137 14.488-4.14 25.304-6.81 37.455h-.868l-7.278-35.652c-.267-1.336-.934-1.803-2.27-1.803H226.55c-1.335 0-2.003.467-2.27 1.803l-6.877 35.652h-.868c-2.67-12.151-4.673-22.967-6.876-37.455h-10.416c2.805 15.289 6.143 30.912 9.481 43.263.601 2.204 2.47 2.738 7.945 2.738s7.544-.735 7.945-2.738l7.077-34.383h.668l7.344 34.383Z\" fill=\"currentColor\"/></svg>",
-        "name": "logoItvNewsMono"
-      }
-    },
-    "items": [
-      {
-        "imagePresets": {},
-        "episodeTitle": "The latest ITV News headlines - as Zahawi faces ethics probe over tax dispute",
-        "episodeId": "6js5d0f",
-        "titleSlug": "the-latest-itv-news-headlines-as-zahawi-faces-ethics-probe-over-tax-dispute",
-        "href": "the-latest-itv-news-headlines-as-zahawi-faces-ethics-probe-over-tax-dispute/6js5d0f",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3Y7BWqIj0NLVTdF1879KED/57b99c9d17219474fa689471bf0cde4b/ITVX_CHARLENE_BULLETIN.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Watch a short summary of today's top stories from the ITV News team.",
-        "dateTime": "2023-01-23T14:00:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/3Y7BWqIj0NLVTdF1879KED/57b99c9d17219474fa689471bf0cde4b/ITVX_CHARLENE_BULLETIN.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Robber convicted of \u00a3700k raid on cyclist Mark Cavendish and wife at home in Essex",
-        "episodeId": "bg7k5hc",
-        "titleSlug": "robber-convicted-of-pound700k-raid-on-cyclist-mark-cavendish-and-wife-at-home-in-essex",
-        "href": "robber-convicted-of-pound700k-raid-on-cyclist-mark-cavendish-and-wife-at-home-in-essex/bg7k5hc",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/68uL1JTjgAl2Yz3rBxsha9/7c1e31447778a404768bea5d42b620db/cavendish_breaking.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Romario Henry has been found guilty of robbing Mark Cavendish and his wife Peta during a raid at their home in November 2021.",
-        "dateTime": "2023-01-23T15:03:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/68uL1JTjgAl2Yz3rBxsha9/7c1e31447778a404768bea5d42b620db/cavendish_breaking.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "PM asks ethics adviser to look into Nadhim Zahawi case",
-        "episodeId": "66kglnl",
-        "titleSlug": "pm-asks-ethics-adviser-to-look-into-nadhim-zahawi-case",
-        "href": "pm-asks-ethics-adviser-to-look-into-nadhim-zahawi-case/66kglnl",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/0AGjn4Aa0vQF3NSZrIMT1/6ed130935dd99308d35a2f3c4881f050/ZAHAWI_INVESTIGATION_THUMB.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Rishi Sunak has asked the independent adviser on ministers' interests to look into Tory chairman Nadhim Zahawi's taxes. Mr Zahawi says he \"acted properly\".",
-        "dateTime": "2023-01-23T13:41:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/0AGjn4Aa0vQF3NSZrIMT1/6ed130935dd99308d35a2f3c4881f050/ZAHAWI_INVESTIGATION_THUMB.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Homes to get discounts for cutting electricity use as temperatures fall",
-        "episodeId": "nyr4v90",
-        "titleSlug": "homes-to-get-discounts-for-cutting-electricity-use-as-temperatures-fall",
-        "href": "homes-to-get-discounts-for-cutting-electricity-use-as-temperatures-fall/nyr4v90",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/YAvRrd9HBlQODbsHw36hS/e6eb8dc800653b4b6c70baf57e33bc09/pylonITVX_STORY_THUMBNAIL.00_00_08_03.Still006.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "The National Grid will give discounts to some households if they switch off between 5pm and 6pm this evening, and potentially tomorrow too.",
-        "dateTime": "2023-01-23T15:24:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/YAvRrd9HBlQODbsHw36hS/e6eb8dc800653b4b6c70baf57e33bc09/pylonITVX_STORY_THUMBNAIL.00_00_08_03.Still006.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Thousands of ambulance workers on strike again across England and Wales",
-        "episodeId": "7hgl46l",
-        "titleSlug": "thousands-of-ambulance-workers-on-strike-again-across-england-and-wales",
-        "href": "thousands-of-ambulance-workers-on-strike-again-across-england-and-wales/7hgl46l",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4ZXLKxokRWKO1O42AF2CXi/21eabf01096f7e62d0412bf22eb4e68a/AMBULANCE_STRIKES_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "999 calls that aren't life-threatening may not be responded to today, as ambulance staff strike for the third time this winter.",
-        "dateTime": "2023-01-23T14:21:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/4ZXLKxokRWKO1O42AF2CXi/21eabf01096f7e62d0412bf22eb4e68a/AMBULANCE_STRIKES_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "The Rundown: ITV News' daily update for teenagers",
-        "episodeId": "d0sgy38",
-        "titleSlug": "the-rundown-itv-news-daily-update-for-teenagers",
-        "href": "the-rundown-itv-news-daily-update-for-teenagers/d0sgy38",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6ROsSytG5aYCR29XXr9sMz/085058f22e7ddd4e073329811fe727d3/THE_RUNDOWN_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Watch a new edition of The Rundown every afternoon.",
-        "dateTime": "2023-01-23T15:23:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/6ROsSytG5aYCR29XXr9sMz/085058f22e7ddd4e073329811fe727d3/THE_RUNDOWN_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Ofgem announces review following spike in households forced onto prepayment meters",
-        "episodeId": "z97x0j2",
-        "titleSlug": "ofgem-announces-review-following-spike-in-households-forced-onto-prepayment-meters",
-        "href": "ofgem-announces-review-following-spike-in-households-forced-onto-prepayment-meters/z97x0j2",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/Ia4GkiogPfJA6qNjVahV9/b89d7a78899d91fe3ca4aef2fd84ba33/PREPAYMENT_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Hundreds of thousands of energy customers struggling with their bills have been moved to more costly prepayment meters - often without their knowledge.",
-        "dateTime": "2023-01-23T13:53:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/Ia4GkiogPfJA6qNjVahV9/b89d7a78899d91fe3ca4aef2fd84ba33/PREPAYMENT_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "BBC chairman asks panel to review how he was hired following Johnson loan claims",
-        "episodeId": "9wdccp2",
-        "titleSlug": "bbc-chairman-asks-panel-to-review-how-he-was-hired-following-johnson-loan-claims",
-        "href": "bbc-chairman-asks-panel-to-review-how-he-was-hired-following-johnson-loan-claims/9wdccp2",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2KkRiXwXei6PMdeHylstyt/688f64d27f58366ccab99c607b250acb/BBC_THUMBNAIL.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "BBC chairman Richard Sharp has asked for a scrutiny panel to examine potential conflicts of interest over his role in helping Boris Johnson secure a loan.",
-        "dateTime": "2023-01-23T13:32:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/2KkRiXwXei6PMdeHylstyt/688f64d27f58366ccab99c607b250acb/BBC_THUMBNAIL.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Rishi Sunak tells ITV News he is \"doing what's right\" as walkouts continue ",
-        "episodeId": "z3szftf",
-        "titleSlug": "rishi-sunak-tells-itv-news-he-is-doing-whats-right-as-walkouts-continue",
-        "href": "rishi-sunak-tells-itv-news-he-is-doing-whats-right-as-walkouts-continue/z3szftf",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/3eIxVW1CKD1ko2AQCe6iLF/35e5f9aa51e4515ba97ea2f50d567416/SUNAK_STRIKES.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "The prime minister said the biggest challenge the country faces is inflation and that's what his government is focusing on. ",
-        "dateTime": "2023-01-23T13:30:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/3eIxVW1CKD1ko2AQCe6iLF/35e5f9aa51e4515ba97ea2f50d567416/SUNAK_STRIKES.jpg?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Thousands of passengers stuck at Heathrow as flights cancelled due to freezing fog",
-        "episodeId": "m08jlmw",
-        "titleSlug": "thousands-of-passengers-stuck-at-heathrow-as-flights-cancelled-due-to-freezing-fog",
-        "href": "thousands-of-passengers-stuck-at-heathrow-as-flights-cancelled-due-to-freezing-fog/m08jlmw",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/41Z0PuwWJCo4DYyqgTfJxw/0380dc195df5d423c414da2fa9e49fef/HEATHROW_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Plunging temperatures have caused major disruption at the UK's busiest airport, with British Airways axeing around 80 flights this morning.",
-        "dateTime": "2023-01-23T14:23:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/41Z0PuwWJCo4DYyqgTfJxw/0380dc195df5d423c414da2fa9e49fef/HEATHROW_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Hollywood star Ryan Reynolds comes to rescue of children's football team",
-        "episodeId": "vq38v57",
-        "titleSlug": "hollywood-star-ryan-reynolds-comes-to-rescue-of-childrens-football-team",
-        "href": "hollywood-star-ryan-reynolds-comes-to-rescue-of-childrens-football-team/vq38v57",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/2PNZp2Mny4ynfXS5Dux3PT/11d091eba6f145fd20c25042c4fdc19a/ITVX_REYNOLDS_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "The Deadpool star made a \u00a31,600 donation towards new kits for the Under 12s team at Wrexham FC, where Reynolds is co-chairman with fellow actor Rob McElhenney.",
-        "dateTime": "2023-01-23T14:27:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/2PNZp2Mny4ynfXS5Dux3PT/11d091eba6f145fd20c25042c4fdc19a/ITVX_REYNOLDS_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Cold and clear: The latest ITV Weather forecast",
-        "episodeId": "t6r5brk",
-        "titleSlug": "cold-and-clear-the-latest-itv-weather-forecast",
-        "href": "cold-and-clear-the-latest-itv-weather-forecast/t6r5brk",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1TLEbE7wYHHf240ABNVkEb/1c75d340c5a76194b81dd2467f402a81/ITVX_PROGRAM_THUMBNAIL_WEATHER.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Watch the latest UK forecast from the ITV Weather team.",
-        "dateTime": "2023-01-22T14:29:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/1TLEbE7wYHHf240ABNVkEb/1c75d340c5a76194b81dd2467f402a81/ITVX_PROGRAM_THUMBNAIL_WEATHER.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Watch Monday's ITV Lunchtime News",
-        "episodeId": "y0g65dr",
-        "titleSlug": "watch-mondays-itv-lunchtime-news",
-        "href": "watch-mondays-itv-lunchtime-news/y0g65dr",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/zGGo34j6UwCeUkVajpXX7/713cc59372d091efc21046ecdf3eb405/ITVX_CHARLENE_PROG_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}",
-        "synopsis": "Catch up with the most recent edition of ITV News.",
-        "dateTime": "2023-01-23T14:50:00Z",
-        "posterImage": "https://images.ctfassets.net/go68aep20o4s/zGGo34j6UwCeUkVajpXX7/713cc59372d091efc21046ecdf3eb405/ITVX_CHARLENE_PROG_THUMBNAIL.png?w={width}&h={height}&q={quality}&fm={image_format}"
-      },
-      {
-        "imagePresets": {},
-        "episodeTitle": "Watch Thursday's ITV Evening News",
-        "encodedEpisodeId": {
-          "letterA": "2a4545a1846",
-          "underscore": "2_4545_1846"
+  "shortFormSliderContent": [
+    {
+      "header": {
+        "title": "",
+        "logo": {
+          "iconSrc": "<svg viewBox=\"0 0 300 56\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M7.25 14.388C2.768 14.388 0 11.205 0 7.194 0 3.184 2.767 0 7.25 0c4.484 0 7.255 3.183 7.255 7.194 0 4.01-2.767 7.194-7.254 7.194Zm29.7 34.807-.014.014c-4.451-3.878-6.528-9.35-6.528-15.208v1.397c0 4.523-.722 6.976-2.322 8.694-1.404 1.508-3.613 2.328-6.044 2.328-2.37 0-4.473-.791-5.725-2.113-1.31-1.382-1.918-3.298-1.918-6.13V20.444c0-.76-.29-1.117-1.147-1.117H1.221c-.846 0-1.125.332-1.125 1.124v16.014c0 6.392 1.649 10.055 4.525 12.92 3.74 3.739 10.139 5.411 16.204 5.411 6.057 0 12.372-2.143 16.11-5.587h.002l.014-.014Zm67.596-29.654c1.048.319 3.139.956 3.914 1.204.803.243 1.153.666 1.153 1.17 0 .499-.292 1.29-.691 2.367l-.016.044c-3.256 8.827-7.757 18.402-13.065 26.499-2.017 3.086-4.26 3.982-7.994 3.982-3.942 0-5.704-1.046-7.636-3.91-1.029-1.506-2.088-3.147-3.387-5.16-.363-.563-.745-1.155-1.15-1.78l-.003-.005c-4.17 6.818-11.31 10.83-21.024 10.83-7.36 0-14.023-2.256-17.693-5.597-4.451-3.879-6.529-9.358-6.529-15.216V8.186c0-1.328.347-2.249 1.097-2.933 1.108-1.006 3.38-1.497 6.062-1.497 2.682 0 4.961.491 6.062 1.497.743.684 1.097 1.597 1.097 2.933v11.148h11.323c.857 0 1.158.343 1.158 1.117v6.804c0 .759-.301 1.117-1.157 1.117h-6.37a12.604 12.604 0 0 1-4.954-.863v7.072c0 4.215.888 6.74 2.714 8.616 1.918 1.977 4.858 3.051 8.67 3.051 8.032 0 12.19-5.042 12.19-10.61 0-2.214-.646-4.017-1.935-6.227l-.032-.05c-1.154-1.967-1.465-2.801-1.465-3.911 0-3.277 5.8-6.786 9.713-6.786 1.395 0 2.29.34 3.238 1.457.391.48.746.989 1.062 1.522.96 1.563 2.556 4.366 4.374 7.556v.001c.89 1.561 1.831 3.215 2.777 4.862 1.865 3.245 3.868 6.847 4.955 8.917 3.312-5.68 7.024-14.8 9.462-22.918.244-.813.626-1.207 1.334-1.207.375 0 1.009.157 2.746.687ZM285.178 8.138c4.34 0 8.68.668 12.151 1.67l-.801 7.878c-3.271-.802-7.21-1.536-10.816-1.536-5.675 0-8.145 1.803-8.145 5.074 0 2.871 1.803 4.073 6.61 5.408l3.538 1.002c5.675 1.602 8.012 3.07 9.681 5.207 1.669 2.137 2.604 4.74 2.604 8.546 0 10.349-7.01 14.087-17.759 14.087-5.275 0-10.683-.934-13.887-1.936-1.069-.334-1.469-.734-1.469-1.87 0-1.134.334-3.004.734-4.406.401-1.402.868-1.736 1.469-1.736.267 0 .601.067 1.269.267 3.071.868 6.876 1.67 11.082 1.67 6.21 0 8.747-1.736 8.747-5.475 0-3.338-2.07-4.607-6.744-6.009l-4.473-1.335c-3.872-1.135-6.476-2.404-8.279-4.34-1.802-1.936-3.071-4.74-3.071-8.746 0-8.079 5.608-13.42 17.559-13.42ZM144.84 52.27l-16.891-30.178v31.046c0 1.335-.868 2.003-4.607 2.003-3.872 0-4.473-.668-4.473-2.07V8.806h11.283l19.095 34.183V8.806h9.08V52.27c0 2.203-2.604 2.737-6.209 2.737-4.474 0-6.276-.935-7.278-2.737Zm19.679-41.328c0-1.602.601-2.136 2.337-2.136h28.976v7.878h-21.565v10.75h18.427v7.81h-18.427v11.684h21.965v7.879h-29.376c-1.736 0-2.337-.534-2.337-2.137V10.942Zm75.184 41.127c.4 2.003 2.47 2.738 7.945 2.738 5.474 0 7.344-.534 7.945-2.738 3.204-12.284 6.743-27.974 9.48-43.263h-10.281c-2.137 14.488-4.14 25.304-6.81 37.455h-.868l-7.278-35.652c-.267-1.336-.934-1.803-2.27-1.803H226.55c-1.335 0-2.003.467-2.27 1.803l-6.877 35.652h-.868c-2.67-12.151-4.673-22.967-6.876-37.455h-10.416c2.805 15.289 6.143 30.912 9.481 43.263.601 2.204 2.47 2.738 7.945 2.738s7.544-.735 7.945-2.738l7.077-34.383h.668l7.344 34.383Z\" fill=\"currentColor\"/></svg>",
+          "name": "logoItvNewsMono"
         },
-        "encodedProgrammeId": {
-          "letterA": "2a4545",
-          "underscore": "2_4545"
+        "iconTitle": "ITV News",
+        "linkHref": "/watch/categories/news",
+        "linkText": "View All"
+      },
+      "items": [
+        {
+          "imagePresets": {},
+          "episodeTitle": "The latest ITV News headlines - as thousands of NHS consultants go on strike ",
+          "episodeId": "6js5d0f",
+          "titleSlug": "the-latest-itv-news-headlines-as-thousands-of-nhs-consultants-go-on-strike",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/6Hbjrkr1wDEO4dHjdO4wpK/1a1e8ed0d6a61fa165da0a36599b934e/LU_DTRAP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Watch a short summary of today's top stories from the ITV News team.",
+          "dateTime": "2023-07-20T15:52:00Z",
+          "duration": 117,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/1oitOHUXMIYCdttQBYtqRo/4803e3ff8e4ec42db5a82e88b2760eaa/lu_poster.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
         },
-        "titleSlug": "watch-thursdays-itv-evening-news",
-        "programmeTitle": "ITV Evening News",
-        "episodeId": "2/4545/1846",
-        "programmeId": "2/4545",
-        "href": "watch-thursdays-itv-evening-news/2/4545/2/4545/1846",
-        "imageUrl": "https://images.ctfassets.net/go68aep20o4s/66dXNkJouk34NWDufivLCv/05f5673cbe921e17dbdaa143b82de6d5/Mary_Programme_Thumbnail.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
-        "dateTime": "2023-02-02T20:34:00Z"
-      }
-    ],
-    "key": "newsShortform",
-    "isRail": true,
-    "dataTestId": "news-rail",
-    "tileType": "news"
-  },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Thousands of senior doctors in England begin a 48-hour walkout ",
+          "episodeId": "5npt32k",
+          "titleSlug": "thousands-of-senior-doctors-in-england-begin-a-48-hour-walkout",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4WR4JHWnIn2T7SndwQ3bVt/b413fdbe46eb6f1bdd23ecb0e0db24f7/CONSULTANTS_NEW_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Consultant doctors and hospital-based dentists have begun a two-day strike in England. NHS bosses have warned planned care will come to a \"virtual standstill\".",
+          "dateTime": "2023-07-20T12:54:00Z",
+          "duration": 326,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/1kz8ctBvi4PPFBN7JdZ2sI/2f2ccf90e6d2786e756c97b5f2284338/CONSULTANTS_CLEAN.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Some supermarkets not displaying prices as clearly as they should, watchdog says",
+          "episodeId": "k2qdqwj",
+          "titleSlug": "some-supermarkets-not-displaying-prices-as-clearly-as-they-should-watchdog-says",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4qX9bX2b2Vr1GN1SgjDsZP/5091d85d16be422932fa31e5f05bc777/CAROLINE_THUMBS.00_00_02_15.Still008.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "The Competition and Markets Authority has said this could be preventing shoppers from comparing prices effectively.",
+          "dateTime": "2023-07-20T12:55:00Z",
+          "duration": 130,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/dPmcuhKlnAg5wEcStz2xO/37a9b4161487a00cc9a0fcaaaeb0b6c6/NOSTRAP_GROCERY.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Temperatures in America's Death Valley continue to soar after one tourist dies",
+          "episodeId": "v9mbwpr",
+          "titleSlug": "temperatures-in-americas-death-valley-continue-to-soar-after-one-tourist-dies",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/wOfCBfpMQyJeHhSeofl0L/f99e2e58406647ef5d10138ece06df22/death_valley.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Temperatures in Death Valley, in California have soared higher than 50C in recent days as the world struggles with record-breaking heat.",
+          "dateTime": "2023-07-20T12:56:00Z",
+          "duration": 81,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/2TvcPeNBG9snXVQWA43wdU/71fc78a5d2305fb9f30ba84190468e73/dan_pic.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Women's World Cup kicks off in New Zealand and Australia",
+          "episodeId": "7tnp1pb",
+          "titleSlug": "womens-world-cup-kicks-off-in-new-zealand-and-australia",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/588YHdTe0ql4PkNY5XU2ya/b31132e18c96e1d26096eefa21fe5a71/ITVX_THUMB_WC_LTN_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "The opening ceremony took place in Auckland ahead of the first games. England's Lionesses will kick off their campaign on Saturday against Haiti.",
+          "dateTime": "2023-07-20T09:30:00Z",
+          "duration": 61,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/1tJxbIJcd3LU4t9yWH5mLX/72d32f7ebebdb36c9069dbc4ab7b3f90/2.73056762.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "The journey of women's football: From outright ban to record Women's World Cup",
+          "episodeId": "lg1k27m",
+          "titleSlug": "the-journey-of-womens-football-from-outright-ban-to-record-womens-world-cup",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/35YLqJ6E4TZrEG7Nh7CY2B/6c9bf51414b5682f941188e43e216188/football_3.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "After their memorable win at the Euros last year, England's Lionesses have become household names - but the journey to get there hasn't been an easy one.",
+          "dateTime": "2023-07-20T11:50:00Z",
+          "duration": 177,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/zs7JSO4mLMgrWIyKrdrhD/d62caad880b7fef78bab3f6646966c13/FOOTBALL_NEW.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "How difficult is it to travel on holiday sustainably? ",
+          "episodeId": "hjjmvm8",
+          "titleSlug": "how-difficult-is-it-to-travel-on-holiday-sustainably",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/1EHzrqvA2WDv76Pe716MQT/b7c70fe0ff9a4d85e7543958818cff6e/TRAINVPLANE_THUMB.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Greenpeace are calling on the government to ban short-haul flights as southern Europe feels the scorching impact of climate change. ",
+          "dateTime": "2023-07-20T15:37:00Z",
+          "duration": 111,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/6iiATUhJoNGmxgIWT76In5/12c19107ce47d7c0415e166c7891cec8/TRAIN_NO_S.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "20,000 RMT members walk out in latest rail strike at start of school holidays",
+          "episodeId": "79v86rg",
+          "titleSlug": "20000-rmt-members-walk-out-in-latest-rail-strike-at-start-of-school-holidays",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7gFqx4wggeCj1vWbA486aQ/01238fd6cf2161fbaa001b57e9d057b6/ITVX_THUMB_LTN_RAIL_STRIKES_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Rail workers in the RMT union are walking out for 24-hours over pay and conditions, ahead of further strike action on the 22nd and 29th of July.",
+          "dateTime": "2023-07-20T12:56:00Z",
+          "duration": 167,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/G06dBSViYGuxrR6QgJG8a/b10c164772d059dcca30f1dd8aece01d/2.72455090.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Two people killed after gunman opened fire in Auckland, police confirm",
+          "episodeId": "vwjs2c3",
+          "titleSlug": "two-people-killed-after-gunman-opened-fire-in-auckland-police-confirm",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/gdwbL8u4U45AsnDjr5VcW/a6d25aa87f456e353ce00ed6499d8138/ITVX_THUMB_NZ_SHOOTING_.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "The New Zealand Prime Minister has confirmed that two people are dead after a gunman stormed a construction site. The shooter is also dead.",
+          "dateTime": "2023-07-20T13:53:00Z",
+          "duration": 195,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/UYO2XqsHMI0N4q69Ry1KT/7f853b634c79f36b2f4c9cb15fe686a2/2.73055017.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Funding of monarchy recalculated after Crown Estate\u2019s boost from wind farm deals",
+          "episodeId": "q53r0fz",
+          "titleSlug": "funding-of-monarchy-recalculated-after-crown-estates-boost-from-wind-farm-deals",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4KWyFZDOWC9u5Eg6nzyMZg/050ce1ec6f6ace91669cc4eeb987258f/SOVEREIGN.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "The Sovereign Grant - used to fund the monarchy's official duties - will be 12% of the Crown Estate's net profits next year, down from 25%.",
+          "dateTime": "2023-07-20T13:00:00Z",
+          "duration": 102,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/4JmCjfmVrOCx1hggL9PPu8/67510730cac838719fc46f3c580ce4d3/SOVEREIGN_NO_STRAP.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "The Rundown: ITV News' daily update for teenagers",
+          "episodeId": "d0sgy38",
+          "titleSlug": "the-rundown-itv-news-daily-update-for-teenagers",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/5FjKNHjnLplbYtN2dNb26P/ec6fa78add2b584a311f123f1e020217/rundown.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Watch a new edition of The Rundown every afternoon.",
+          "dateTime": "2023-07-20T15:36:00Z",
+          "duration": 105,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/5FjKNHjnLplbYtN2dNb26P/ec6fa78add2b584a311f123f1e020217/rundown.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Sunny spells and scattered showers: The latest ITV Weather",
+          "episodeId": "t6r5brk",
+          "titleSlug": "sunny-spells-and-scattered-showers-the-latest-itv-weather",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/7fl401gxYnSc7iHF2D7A0N/b57743a6d09e1edb981f48bc674bce46/WEATHERF.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Watch the latest UK forecast from the ITV Weather team.",
+          "dateTime": "2023-07-20T12:13:00Z",
+          "duration": 63,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/7MaWXmgQPE2UgKGXzaTUt3/552f790cd7901cad21c7dcfa39846599/LUCY.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        },
+        {
+          "imagePresets": {},
+          "episodeTitle": "Watch Thursday's ITV Lunchtime News",
+          "episodeId": "lmq6wpt",
+          "titleSlug": "watch-thursdays-itv-lunchtime-news",
+          "imageUrl": "https://images.ctfassets.net/go68aep20o4s/4iLgz55VkJECf8TK0Ea8H7/457213027c633b8c54d5ea068ac3f8e6/GERAINT_NEWS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "synopsis": "Catch up with the latest edition of ITV News.",
+          "dateTime": "2023-07-20T14:33:00Z",
+          "duration": 1336,
+          "posterImage": "https://images.ctfassets.net/go68aep20o4s/4iLgz55VkJECf8TK0Ea8H7/457213027c633b8c54d5ea068ac3f8e6/GERAINT_NEWS.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+          "href": "/watch/news/undefined"
+        }
+      ],
+      "key": "newsShortForm",
+      "isRail": true,
+      "dataTestId": "news-rail",
+      "tileType": "news"
+    }
+  ],
   "trendingSliderContent": {
     "header": {
       "title": "Trending"

--- a/test/web/test_itvx_api.py
+++ b/test/web/test_itvx_api.py
@@ -465,7 +465,7 @@ class Playlists(unittest.TestCase):
     def test_playlist_news_collection_items(self):
         """Short news items form the collection 'news' are all just mp4 files."""
         page_data = parsex.scrape_json(fetch.get_document('https://www.itv.com/'))
-        for item in page_data['newsShortformSliderContent']['items']:
+        for item in page_data['shortFormSliderContent'][0]['items']:
             is_short = True
             if 'encodedProgrammeId' in item.keys():
                 # The new item is a 'normal' catchup title
@@ -477,7 +477,7 @@ class Playlists(unittest.TestCase):
                 is_short = False
             else:
                 # This news item is a 'short' item
-                url = 'https://www.itv.com/watch/news/' + item['href']
+                url = '/'.join(('https://www.itv.com/watch/news', item['titleSlug'], item['episodeId']))
             playlist_url = itvx.get_playlist_url_from_episode_page(url)
             strm_data = self.get_playlist_catchup(playlist_url)
             if is_short:

--- a/test/web/test_itvx_html.py
+++ b/test/web/test_itvx_html.py
@@ -20,7 +20,7 @@ from support.object_checks import (
     misses_keys,
     is_url,
     is_iso_utc_time,
-    check_news_category_clip_item,
+    check_news_clip_item,
     check_category_item
 )
 from support import testutils
@@ -84,7 +84,7 @@ class MainPage(unittest.TestCase):
         # testutils.save_doc(page, 'html/index.html')
         page_props = parsex.scrape_json(page)
         # testutils.save_json(page_props, 'html/index-data.json')
-        has_keys(page_props, 'heroContent', 'editorialSliders', 'newsShortformSliderContent', 'trendingSliderContent')
+        has_keys(page_props, 'heroContent', 'editorialSliders', 'shortFormSliderContent', 'trendingSliderContent')
 
         self.assertIsInstance(page_props['heroContent'], list)
         for item in page_props['heroContent']:
@@ -134,13 +134,11 @@ class MainPage(unittest.TestCase):
             # is no way to check the item's type
             # has_keys(item, 'encodedEpisodeId', obj_name='trending-slider_' + item['title'])
 
-        self.assertIsInstance(page_props['newsShortformSliderContent'], dict)
-        for item in page_props['newsShortformSliderContent']['items']:
-            # Field 'synopsys' may be absent occasionally.
-            has_keys(item, 'episodeTitle', 'imageUrl', 'href', 'dateTime',
-                     'titleSlug', obj_name='news-slider')
-            self.assertFalse(is_url(item['href']))
-            self.assertFalse(item['href'].startswith('/'))
+        self.assertIsInstance(page_props['shortFormSliderContent'], list)
+        # Currently the list contains only the news rail.
+        self.assertEqual(1, len(page_props['shortFormSliderContent']))
+        for item in page_props['shortFormSliderContent'][0]['items']:
+            check_news_clip_item(item)
 
     def test_get_itvx_logo(self):
         resp = requests.get('https://app.10ft.itv.com/itvstatic/assets/images/brands/itvx/itvx-logo-for-light-'
@@ -342,10 +340,10 @@ class Categories(unittest.TestCase):
         news_data = data['newsData']
         # Check the hero rail
         for item in news_data['heroAndLatestData']:
-            check_news_category_clip_item(item)
+            check_news_clip_item(item)
         for item in news_data['longformData']:
             check_category_item(item)
         for  rail in news_data['curatedRails']:
             self.assertTrue(isinstance(rail['title'], str) and rail['title'])
             for item in rail['clips']:
-                check_news_category_clip_item(item)
+                check_news_clip_item(item)

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -111,8 +111,8 @@ class TestPlayCatchup(unittest.TestCase):
     def test_play_short_news_item(self):
         # get the first news item from the main page
         page_data = itvx.get_page_data('https://www.itv.com/')
-        news_item = page_data['newsShortformSliderContent']['items'][0]
-        item_url = 'https://www.itv.com/watch/news/' + news_item['href']
+        news_item = page_data['shortFormSliderContent'][0]['items'][0]
+        item_url = '/'.join(('https://www.itv.com/watch/news', news_item['titleSlug'], news_item['episodeId']))
         # play the item
         result = main.play_title(MagicMock(), item_url, 'news item')
         self.assertIsInstance(result.params, MutableMapping)


### PR DESCRIPTION
This fixes:
- Subcategories of category 'News' fail to open with KeyError: 'href'.
- Missing collection 'News' on the home page.