### PR TITLE
Prevent forced values for title and plot on playable items

### DIFF
--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -15,6 +15,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from codequick import Listitem
+from xbmcgui import ListItem as XbmcListItem
 
 from test.support.testutils import open_json, open_doc, HttpResponse
 from test.support import object_checks
@@ -287,7 +288,7 @@ class PlayStreamLive(TestCase):
     @patch('resources.lib.itv_account.ItvSession.cookie', new={'Itv.Session': 'blabla'})
     def test_play_live_by_channel_name(self, _, __, p_req_strm):
         result = main.play_stream_live.test(channel='ITV', url=None)
-        self.assertIsInstance(result, Listitem)
+        self.assertIsInstance(result, XbmcListItem)
         # Assert channel name is converted to a full url
         self.assertEqual(1, len(p_req_strm.call_args_list))
         self.assertTrue(object_checks.is_url(p_req_strm.call_args_list[0], '/ITV'))
@@ -303,7 +304,7 @@ class PlayStreamCatchup(TestCase):
     @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_news_short.json'))
     def test_play_short_news_item(self, _):
         result = main.play_stream_catchup.test('some/url', 'a short news item')
-        self.assertIsInstance(result, Listitem)
+        self.assertIsInstance(result, XbmcListItem)
 
     @patch('resources.lib.itv.get_catchup_urls', side_effect=errors.AccessRestrictedError)
     def test_play_premium_episode(self, _):

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -4,6 +4,7 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
 # ----------------------------------------------------------------------------------------------------------------------
+import xbmcgui
 
 from test.support import fixtures
 fixtures.global_setup()
@@ -12,7 +13,7 @@ import types
 import json
 
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from codequick import Listitem
 from xbmcgui import ListItem as XbmcListItem
@@ -289,9 +290,12 @@ class PlayStreamLive(TestCase):
     def test_play_live_by_channel_name(self, _, __, p_req_strm):
         result = main.play_stream_live.test(channel='ITV', url=None)
         self.assertIsInstance(result, XbmcListItem)
+        self.assertEqual('ITV', result.getLabel())
+        self.assertEqual('true', result._props['IsPlayable'])
         # Assert channel name is converted to a full url
         self.assertEqual(1, len(p_req_strm.call_args_list))
         self.assertTrue(object_checks.is_url(p_req_strm.call_args_list[0], '/ITV'))
+
     @patch('resources.lib.fetch.post_json', return_value=open_json('playlists/pl_itv1.json'))
     def test_play_stream_live_without_credentials(self, _):
         itv_account.itv_session().log_out()
@@ -301,21 +305,65 @@ class PlayStreamLive(TestCase):
 
 
 class PlayStreamCatchup(TestCase):
+    def setUp(self) -> None:
+        itv_account._itv_session_obj = None
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Ensure to clear patched session objects
+        itv_account._itv_session_obj = None
+
     @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_news_short.json'))
     def test_play_short_news_item(self, _):
         result = main.play_stream_catchup.test('some/url', 'a short news item')
         self.assertIsInstance(result, XbmcListItem)
+
+    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=HttpResponse())
+    @patch('resources.lib.itv_account.ItvSession.cookie', new={'Itv.Session': ''})
+    def test_play_episode(self, _, __):
+        result = main.play_stream_catchup.test('some/url', 'my episode')
+        self.assertIsInstance(result, XbmcListItem)
+        self.assertEqual('my episode', result.getLabel())
+        self.assertEqual('my episode', result._info['video']['title'])
+        with self.assertRaises(KeyError):
+            result._info['video']['plot']
+        self.assertEqual('true', result._props['IsPlayable'])
+        self.assertRaises(AttributeError, getattr, result, '_subtitles')
+
+    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=HttpResponse())
+    @patch('resources.lib.itv_account.ItvSession.cookie', new={'Itv.Session': ''})
+    def test_play_episode_without_title(self, _, __):
+        result = main.play_stream_catchup.test('some/url', '')
+        self.assertIsInstance(result, XbmcListItem)
+        self.assertEqual('', result.getLabel())
+        with self.assertRaises(KeyError):
+            result._info['video']['title']
+
+    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.main.create_dash_stream_item', return_value=xbmcgui.ListItem())
+    @patch('resources.lib.itv.get_vtt_subtitles', return_value=('my/subs.file', ))
+    def test_play_episode_with_subtitles(self, _, __, ___):
+        result = main.play_stream_catchup.test('some/url', 'my episode')
+        self.assertEqual(len(result._subtitles), 1)
+
+    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.main.create_dash_stream_item', return_value=xbmcgui.ListItem())
+    @patch('resources.lib.itv.get_vtt_subtitles', return_value=None)
+    def test_play_episode_without_subtitles(self, _, __, ___):
+        result = main.play_stream_catchup.test('some/url', 'my episode')
+        self.assertRaises(AttributeError, getattr, result, '_subtitles')
 
     @patch('resources.lib.itv.get_catchup_urls', side_effect=errors.AccessRestrictedError)
     def test_play_premium_episode(self, _):
         result = main.play_stream_catchup.test('url', '')
         self.assertIs(result, False)
 
-    @patch('resources.lib.fetch.post_json', return_value=open_json('playlists/pl_itv1.json'))
+    @patch('resources.lib.fetch.post_json', return_value=open_json('playlists/pl_doc_martin.json'))
     def test_play_catchup_without_credentials(self, _):
-        # Ensure we have an empty session object
+        # Ensure we have an empty file and session object
         itv_account.itv_session().log_out()
-        itv_account._itv_session_obj = None
         result = main.play_stream_catchup.test('url', '')
         self.assertFalse(result)
 

--- a/test/support/fixtures.py
+++ b/test/support/fixtures.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 import os
+from typing import Dict, List, Tuple
 
 from unittest.mock import patch
 
@@ -37,6 +38,9 @@ def global_setup():
             pass
         patch('xbmcaddon.Addon.getSettingString',
               new=lambda self, item: 'file' if item == 'log-handler' else '').start()
+
+        # Use an xbmcgui.ListItem that stores the values which have been set.
+        patch_listitem()
 
 
 patch_1 = None
@@ -85,3 +89,89 @@ def setup_web_test(*args):
     # Sign in once per test run.
     if not credentials_set:
         set_credentials()
+
+
+def patch_listitem():
+    import xbmcgui
+
+    class LI(xbmcgui.ListItem):
+        def __init__(self, label: str = "",
+                     label2: str = "",
+                     path: str = "",
+                     offscreen: bool = False) -> None:
+            super().__init__()
+            assert isinstance(label, str)
+            assert isinstance(label2, str)
+            assert isinstance(path, str)
+            assert isinstance(offscreen, bool)
+            self._label = label
+            self._label2 = label2
+            self._path = path
+            self._offscreen = offscreen
+            self._is_folder = False
+            self._art = {}
+            self._info = {}
+            self._props = {}
+
+        def getLabel(self) -> str:
+            return self._label
+
+        def getLabel2(self) -> str:
+            return self._label2
+
+        def setLabel(self, label: str) -> None:
+            assert isinstance(label, str), "Argument 'label' must be a string."
+            self._label = label
+
+        def setLabel2(self, label: str) -> None:
+            assert isinstance(label, str), "Argument 'label' must be a string."
+            self._label2 = label
+
+        def setArt(self, dictionary: Dict[str, str]) -> None:
+            assert isinstance(dictionary, dict), "Argument 'dictionary' must be a dict."
+            self._art.update(dictionary)
+
+        def setIsFolder(self, isFolder: bool) -> None:
+            assert isinstance(isFolder, bool), "Argument 'isFolder' must be a boolean."
+            self._is_folder = isFolder
+
+        def setInfo(self, type: str, infoLabels: Dict[str, str]) -> None:
+            assert isinstance(type, str), "Argument 'type' must be a string."
+            assert isinstance(infoLabels, dict), "Argument 'infoLabels' must be a dict."
+            assert type in ('video', 'music', 'pictures', 'game')
+            info_dict = self._info.setdefault(type, {})
+            info_dict.update(infoLabels)
+
+        def setProperty(self, key: str, value: str) -> None:
+            assert isinstance(key, str), "Argument 'key' must be a string."
+            assert isinstance(value, str), "Argument 'value' must be a string."
+            self._props[key] = value
+
+        def setProperties(self, dictionary: Dict[str, str]) -> None:
+            assert isinstance(dictionary, dict), "Argument 'dictionary' must be a dict."
+            self._props.update(dictionary)
+
+        def getProperty(self, key: str) -> str:
+            assert isinstance(key, str), "Argument 'key' must be a string."
+            return self._props['key']
+
+        def setPath(self, path: str) -> None:
+            assert isinstance(path, str), "Argument 'path' must be a string."
+            self._path = path
+
+        def setMimeType(self, mimetype: str) -> None:
+            assert isinstance(mimetype, str), "Argument 'mimetype' must be a string."
+            self._mimetype = mimetype
+
+        def setContentLookup(self, enable: bool) -> None:
+            assert isinstance(enable, bool), "Argument 'enable' must be a boolean."
+            self._content_lookup = enable
+
+        def setSubtitles(self, subtitleFiles: List[str]) -> None:
+            assert isinstance(subtitleFiles, (list, tuple)), "Argument 'subtitleFiles' must be a tuple or a list."
+            self._subtitles = subtitleFiles
+
+        def getPath(self) -> str:
+            return self._path
+
+    xbmcgui.ListItem = LI

--- a/test/test_docs/playlists/pl_doc_martin.json
+++ b/test/test_docs/playlists/pl_doc_martin.json
@@ -1,0 +1,301 @@
+{
+  "StatusCode": 200,
+  "AdditionalInfo": {
+    "TransactionId": "oas-magni-938323-CnHSOp",
+    "Message": null
+  },
+  "Playlist": {
+    "Video": {
+      "Duration": "00:46:10:160",
+      "Timecodes": {
+        "OpeningTitles": {
+          "StartTime": "00:00:00:000",
+          "EndTime": "00:00:37:120",
+          "Skippable": true
+        },
+        "EndCredits": {
+          "StartTime": "00:45:41:120",
+          "EndTime": "00:46:06:080",
+          "Skippable": true
+        },
+        "Recap": null
+      },
+      "Base": "https://itvpnpctv.blue.content.itv.com/",
+      "MediaFiles": [
+        {
+          "Href": "1-7665-0049-001/21/1/VAR039/1-7665-0049-001_21_1_VAR039.ism/.mpd?filter=%28%28type%3D%3D%22video%22%26%26DisplayHeight%3C%3D576%29%7C%7C%28type%21%3D%22video%22%29%29&hdnea=st%3D1690128928~exp%3D1690150528~acl%3D/1-7665-0049-001/%2A~data%3Dnohubplus~hmac%3D40deef17f89d54b18efdb2e89cc65089b0125071627fbb15da581eb44edbd47a",
+          "KeyServiceUrl": "https://itvpnp.live.ott.irdeto.com/Widevine/getlicense?CrmId=itvpnp&AccountId=itvpnp&ContentId=1-7665-0049-001_21",
+          "Resolution": null,
+          "Cdn": null
+        }
+      ],
+      "Subtitles": [
+        {
+          "Href": "https://itvpnpsubtitles.blue.content.itv.com/1-7665-0049-001/Subtitles/2/WebVTT-OUT-OF-BAND/1-7665-0049-001_Series1662044575_TX000000.vtt"
+        }
+      ],
+      "Token": null
+    },
+    "ProductionId": "1/7665/0049#001",
+    "VideoType": "CATCHUP",
+    "ContentBreaks": [
+      {
+        "TimeCode": "00:00:00:000",
+        "Actions": [
+          {
+            "Type": "ident",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videoident/adpos=iden1/breaknum=0/viewid=0.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "ident",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videoident/adpos=iden2/breaknum=0/viewid=0.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=1/breaknum=0/viewid=0.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=last/breaknum=0/viewid=0.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast2/breaknum=0/viewid=sponlast2.0.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast1/breaknum=0/viewid=sponlast1.0.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          }
+        ]
+      },
+      {
+        "TimeCode": "00:11:39:760",
+        "Actions": [
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon1/breaknum=1/viewid=spon1.1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon2/breaknum=1/viewid=spon2.1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=1/breaknum=1/viewid=1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=2/breaknum=1/viewid=1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=3/breaknum=1/viewid=1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=last/breaknum=1/viewid=1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videopromo/adpos=promolast1/breaknum=1/viewid=promolast1.1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast2/breaknum=1/viewid=sponlast2.1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast1/breaknum=1/viewid=sponlast1.1.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          }
+        ]
+      },
+      {
+        "TimeCode": "00:27:44:840",
+        "Actions": [
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon1/breaknum=2/viewid=spon1.2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon2/breaknum=2/viewid=spon2.2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=1/breaknum=2/viewid=2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=2/breaknum=2/viewid=2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=3/breaknum=2/viewid=2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=last/breaknum=2/viewid=2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast2/breaknum=2/viewid=sponlast2.2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast1/breaknum=2/viewid=sponlast1.2.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          }
+        ]
+      },
+      {
+        "TimeCode": "00:37:36:760",
+        "Actions": [
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon1/breaknum=3/viewid=spon1.3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon2/breaknum=3/viewid=spon2.3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=1/breaknum=3/viewid=3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=2/breaknum=3/viewid=3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=3/breaknum=3/viewid=3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=last/breaknum=3/viewid=3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast2/breaknum=3/viewid=sponlast2.3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=sponlast1/breaknum=3/viewid=sponlast1.3.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          }
+        ]
+      },
+      {
+        "TimeCode": "00:46:10:160",
+        "Actions": [
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon1/breaknum=end/viewid=spon1.end.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "sponsor",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=videosponsor/adpos=spon2/breaknum=end/viewid=spon2.end.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=1/breaknum=end/viewid=end.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=2/breaknum=end/viewid=end.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=3/breaknum=end/viewid=end.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=4/breaknum=end/viewid=end.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          },
+          {
+            "Type": "advert",
+            "Format": null,
+            "Href": "https://tom.itv.com/itv/tserver/random=6876627850/supertag=dflt,itv.1_7665_0049/area=itvplayer.video/vfunapod=true/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser./rh=x/subserv=x/conttier=free/tppm=x/source=catchup/us=ano/arp=none/tparts=4/tdur=2770/player=html5.desktop/os=linux/pm=free/chanbrand=itv1/site=itv/service=itv.hub/size=video/adpos=last/breaknum=end/viewid=end.542bde09-98b1-47de-b4c4-63ff4892fd52/generic=542bde09-98b1-47de-b4c4-63ff4892fd52/plist=i2.s2.pm1.pr2.m4.po5/plfcid=43896/linked_fcid=43896/platform=desktop/temphint=/default=defaultvideo",
+            "AlternativeText": null
+          }
+        ]
+      }
+    ],
+    "Dog": {
+      "Href": "https://magni.itv.com/img/itv.png"
+    },
+    "ThumbnailScrubbing": null
+  }
+}

--- a/test/web/test_itvx_api.py
+++ b/test/web/test_itvx_api.py
@@ -433,8 +433,8 @@ class Playlists(unittest.TestCase):
         return resp
 
     def test_get_playlist_catchup(self):
-        resp = self.get_playlist_catchup()
-        strm_data = resp
+        strm_data = self.get_playlist_catchup()
+        # testutils.save_json(strm_data, 'playlists/doc_martin.json')
         object_checks.check_catchup_dash_stream_info(strm_data['Playlist'])
 
     def test_get_playlist_premium_catchup(self):

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -12,6 +12,8 @@ import unittest
 from unittest.mock import MagicMock, patch
 from typing import MutableMapping
 
+from xbmcgui import ListItem as XbmcListItem
+
 from resources.lib import main, itvx
 from support import object_checks
 
@@ -90,23 +92,23 @@ class TestGetProductions(unittest.TestCase):
 class TestPlayCatchup(unittest.TestCase):
     def test_play_itv_1(self):
         result = main.play_stream_live(MagicMock(), "itv", 'https://simulcast.itv.com/playlist/itvonline/itv', None)
-        self.assertEqual('itv', result.label)
-        self.assertIsInstance(result.params, MutableMapping)
+        # self.assertEqual('itv', result.getLabel())
+        self.assertIsInstance(result, XbmcListItem)
 
     def test_play_vod_a_touch_of_frost(self):
         result = main.play_stream_catchup(MagicMock(),
                                           url='https://magni.itv.com/playlist/itvonline/ITV3/Y_1774_0002_Y',
                                           name='A Touch of Frost')
-        self.assertEqual('A Touch of Frost', result.label)
-        self.assertIsInstance(result.params, MutableMapping)
+        # self.assertEqual('A Touch of Frost', result.getLabel())
+        self.assertIsInstance(result, XbmcListItem)
 
     def test_play_vod_episode_julia_bradbury(self):
         result = main.play_stream_catchup(MagicMock(),
                                           url='https://magni.itv.com/playlist/itvonline/ITV/10_0852_0001.001',
                                           name='Walks with Julia Bradbury')
-        self.assertEqual('Walks with Julia Bradbury', result.label)
-        self.assertIsInstance(result.params, MutableMapping)
-        self.assertTrue(object_checks.is_url(result.path, '.mpd'))
+        self.assertEqual('Walks with Julia Bradbury', result.getLabel())
+        self.assertIsInstance(result, XbmcListItem)
+        # self.assertTrue(object_checks.is_url(result.getPath(), '.mpd'))
 
     def test_play_short_news_item(self):
         # get the first news item from the main page
@@ -114,9 +116,9 @@ class TestPlayCatchup(unittest.TestCase):
         news_item = page_data['shortFormSliderContent'][0]['items'][0]
         item_url = '/'.join(('https://www.itv.com/watch/news', news_item['titleSlug'], news_item['episodeId']))
         # play the item
-        result = main.play_title(MagicMock(), item_url, 'news item')
-        self.assertIsInstance(result.params, MutableMapping)
-        self.assertTrue(object_checks.is_url(result.path, '.mp4'))
+        result = main.play_title.test(item_url, 'news item')
+        self.assertIsInstance(result, XbmcListItem)
+        # self.assertTrue(object_checks.is_url(result.getPath(), '.mp4'))
 
 
 class TestSearch(unittest.TestCase):

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -14,7 +14,7 @@ from typing import MutableMapping
 
 from xbmcgui import ListItem as XbmcListItem
 
-from resources.lib import main, itvx
+from resources.lib import main, itvx, itv
 from support import object_checks
 
 setUpModule = fixtures.setup_web_test
@@ -92,14 +92,24 @@ class TestGetProductions(unittest.TestCase):
 class TestPlayCatchup(unittest.TestCase):
     def test_play_itv_1(self):
         result = main.play_stream_live(MagicMock(), "itv", 'https://simulcast.itv.com/playlist/itvonline/itv', None)
-        # self.assertEqual('itv', result.getLabel())
+        self.assertEqual('itv', result.getLabel())
         self.assertIsInstance(result, XbmcListItem)
 
     def test_play_vod_a_touch_of_frost(self):
         result = main.play_stream_catchup(MagicMock(),
                                           url='https://magni.itv.com/playlist/itvonline/ITV3/Y_1774_0002_Y',
                                           name='A Touch of Frost')
-        # self.assertEqual('A Touch of Frost', result.getLabel())
+        self.assertEqual('A Touch of Frost', result.getLabel())
+        self.assertRaises(AttributeError, getattr, result, '_subtitles')
+        self.assertIsInstance(result, XbmcListItem)
+
+    def test_play_vod_frost_with_subtitles(self):
+        with patch.object(itv.Script, 'setting', new={'subtitles_show': 'true', 'subtitles_color': 'true'}):
+            result = main.play_stream_catchup(MagicMock(),
+                                              url='https://magni.itv.com/playlist/itvonline/ITV3/Y_1774_0002_Y',
+                                              name='A Touch of Frost')
+        self.assertEqual('A Touch of Frost', result.getLabel())
+        self.assertEqual(1, len(result._subtitles))
         self.assertIsInstance(result, XbmcListItem)
 
     def test_play_vod_episode_julia_bradbury(self):
@@ -108,7 +118,7 @@ class TestPlayCatchup(unittest.TestCase):
                                           name='Walks with Julia Bradbury')
         self.assertEqual('Walks with Julia Bradbury', result.getLabel())
         self.assertIsInstance(result, XbmcListItem)
-        # self.assertTrue(object_checks.is_url(result.getPath(), '.mpd'))
+        self.assertTrue(object_checks.is_url(result.getPath(), '.mpd'))
 
     def test_play_short_news_item(self):
         # get the first news item from the main page
@@ -118,7 +128,7 @@ class TestPlayCatchup(unittest.TestCase):
         # play the item
         result = main.play_title.test(item_url, 'news item')
         self.assertIsInstance(result, XbmcListItem)
-        # self.assertTrue(object_checks.is_url(result.getPath(), '.mp4'))
+        self.assertTrue(object_checks.is_url(result.getPath(), '.mp4'))
 
 
 class TestSearch(unittest.TestCase):


### PR DESCRIPTION
Fixes #35
Resolvers now return an xbmc.ListItem rather than codequick.Listitem. The latter forces values on video info tags 'title' and 'plot', thus preventing Kodi to use this info from the previous item. 
An xbmx.ListItem is passed on to Kodi as is, thus avoiding this issue.