### PR TITLE
add support for shortFormSliders in collections

### DIFF
--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -161,13 +161,28 @@ def main_page_items():
 
 
 def collection_content(url=None, slider=None, hide_paid=False):
+    uk_tz = pytz.timezone('Europe/London')
+    time_fmt = ' '.join((xbmc.getRegion('dateshort'), xbmc.getRegion('time')))
+
     if url:
+        # A collection that has its own dedicated page.
         page_data = get_page_data(url, cache_time=43200)
+        if slider == 'shortFormSlider':
+            # return the items from the collection's shortFormSlider
+            for item in page_data['shortFormSlider']['items']:
+                yield parsex.parse_shortform_item(item, uk_tz, time_fmt)
+            return
+
         collection = page_data['collection']
         editorial_sliders = page_data.get('editorialSliders')
+        shortform_slider = page_data.get('shortFormSlider')
+
+        if shortform_slider is not None:
+            yield parsex.parse_short_form_slider(shortform_slider, url)
+
         if collection is not None:
-            col_items = collection.get('shows', [])
-            progr_gen = (parsex.parse_collection_item(item, hide_paid) for item in col_items)
+            for item in collection.get('shows', []):
+                yield parsex.parse_collection_item(item, hide_paid)
         elif editorial_sliders:
             # Do not sort this list on title
             return list(filter(None, (parsex.parse_slider('', slider) for slider in editorial_sliders)))
@@ -185,19 +200,17 @@ def collection_content(url=None, slider=None, hide_paid=False):
             items_list = None
             for slider in page_data['shortFormSliderContent']:
                 if slider['key'] == 'newsShortForm':
-                    uk_tz = pytz.timezone('Europe/London')
-                    time_fmt = ' '.join((xbmc.getRegion('dateshort'), xbmc.getRegion('time')))
-                    items_list = slider['items']
-                    progr_gen = (parsex.parse_news_collection_item(news_item, uk_tz, time_fmt, hide_paid)
-                                 for news_item in items_list)
+                    for news_item in slider['items']:
+                        yield parsex.parse_shortform_item(news_item, uk_tz, time_fmt, hide_paid)
+
             if items_list is None:
                 logger.warning("News shortFormSlider unexpectedly absent from main page")
-                return []
+                return
 
         elif slider == 'trendingSliderContent':
             items_list = page_data['trendingSliderContent']['items']
-            progr_gen = (parsex.parse_trending_collection_item(trending_item, hide_paid)
-                          for trending_item in items_list)
+            for trending_item in items_list:
+                yield parsex.parse_trending_collection_item(trending_item, hide_paid)
 
         else:
             try:
@@ -205,10 +218,9 @@ def collection_content(url=None, slider=None, hide_paid=False):
             except KeyError:
                 logger.error("Failed to parse collection content: Unknown slider '%s'", slider)
                 return []
-            progr_gen = (parsex.parse_collection_item(item, hide_paid) for item in items_list)
+            for item in items_list:
+                yield parsex.parse_collection_item(item, hide_paid)
 
-    progr_list = sorted(filter(None, progr_gen), key=lambda prog: prog['show']['info']['sorttitle'])
-    return progr_list
 
 
 def episodes(url, use_cache=False):
@@ -387,11 +399,11 @@ def category_news_content(url, sub_cat, rail=None, hide_paid=False):
         return []
 
     if hide_paid:
-        return [parsex.parse_news_collection_item(news_item, uk_tz, time_fmt)
+        return [parsex.parse_shortform_item(news_item, uk_tz, time_fmt)
                 for news_item in items_list
                 if not news_item.get('isPaid')]
     else:
-        return [parsex.parse_news_collection_item(news_item, uk_tz, time_fmt)
+        return [parsex.parse_shortform_item(news_item, uk_tz, time_fmt)
                 for news_item in items_list]
 
 

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -257,10 +257,11 @@ def list_collections(_):
 @Route.register(cache_ttl=-1, content_type='videos')
 @dynamic_listing
 def list_collection_content(addon, url='', slider='', filter_char=None, page_nr=0):
+    """Return the contents of a collection"""
     addon.add_sort_methods(xbmcplugin.SORT_METHOD_UNSORTED,
                            xbmcplugin.SORT_METHOD_VIDEO_SORT_TITLE,
                            disable_autosort=True)
-    shows_list = itvx.collection_content(url, slider, addon.setting.get_boolean('hide_paid'))
+    shows_list = list(filter(None, itvx.collection_content(url, slider, addon.setting.get_boolean('hide_paid'))))
     logger.info("Listed collection %s%s with %s items", url, slider, len(shows_list) if shows_list else 0)
     paginator = Paginator(shows_list, filter_char, page_nr, url=url)
     yield from paginator

--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -124,18 +124,29 @@ def parse_hero_content(hero_data):
         logger.warning("Failed to parse hero item '%s':\n", hero_data.get('title','unknown title'), exc_info=True)
 
 
-def parse_short_form_slider(slider_data):
+def parse_short_form_slider(slider_data, url=None):
+    """Parse a shortFormSlider from the main page.
+
+    Returns the link to the collection page associated with the shortFormSlider.
+
+    """
     # noinspection PyBroadException
     try:
         header = slider_data['header']
         link = header.get('linkHref')
         title = header.get('title') or header.get('iconTitle', '')
-        if not link:
-            return None
+        if url:
+            # A shortFormSlider from a collection page.
+            params = {'url': url, 'slider': 'shortFormSlider'}
+        elif link:
+            # A shortFormSlider from the main page
+            params = {'url': 'https://www.itv.com' + link}
+        else:
+            return
+
         return {'type': 'collection',
-                'playable': False,
                 'show': {'label': title,
-                         'params': {'url': 'https://www.itv.com' + link},
+                         'params': params,
                          'info': {'sorttitle': sort_title(title)}
                          }
                 }
@@ -145,7 +156,7 @@ def parse_short_form_slider(slider_data):
 
 
 def parse_slider(slider_name, slider_data):
-    """Parse editorialSliders from the main page."""
+    """Parse editorialSliders from the main page or from a collection."""
     # noinspection PyBroadException
     try:
         coll_data = slider_data['collection']
@@ -218,30 +229,37 @@ def parse_collection_item(show_data, hide_paid=False):
         return None
 
 # noinspection GrazieInspection
-def parse_news_collection_item(news_item, time_zone, time_fmt, hide_paid=False):
+def parse_shortform_item(item_data, time_zone, time_fmt, hide_paid=False):
+    """Parse an item from a shortFormSlider.
+
+    ShortFormSliders are found on the main page, some collection pages.
+    Items from heroAndLatest and curatedRails in category news also have a shortForm-like content.
+
+    """
     """Parse data found in news collection and in short news clips from news sub-categories
 
     """
     try:
-        if 'encodedProgrammeId' in news_item.keys():
+        if 'encodedProgrammeId' in item_data.keys():
             # The news item is a 'normal' catchup title. Is usually just the latest ITV news.
             # Do not use field 'href' as it is known to have non-a-encoded program and episode Id's which doesn't work.
             url = '/'.join(('https://www.itv.com/watch',
-                            news_item['titleSlug'],
-                            news_item['encodedProgrammeId']['letterA'],
-                            news_item.get('encodedEpisodeId', {}).get('letterA', ''))).rstrip('/')
+                            item_data['titleSlug'],
+                            item_data['encodedProgrammeId']['letterA'],
+                            item_data.get('encodedEpisodeId', {}).get('letterA', ''))).rstrip('/')
         else:
-            # This news item is a 'short item', aka 'news clip'.
-            url = '/'.join(('https://www.itv.com/watch/news', news_item['titleSlug'], news_item['episodeId']))
+            # This item is a 'short item', aka 'news clip'.
+            href = item_data.get('href', '/watch/news/undefined')
+            url = ''.join(('https://www.itv.com', href, '/', item_data['episodeId']))
 
         # dateTime field occasionally has milliseconds. Strip these when present.
-        item_time = pytz.UTC.localize(utils.strptime(news_item['dateTime'][:19], '%Y-%m-%dT%H:%M:%S'))
+        item_time = pytz.UTC.localize(utils.strptime(item_data['dateTime'][:19], '%Y-%m-%dT%H:%M:%S'))
         loc_time = item_time.astimezone(time_zone)
-        title = news_item.get('episodeTitle')
-        plot = '\n'.join((loc_time.strftime(time_fmt), news_item.get('synopsis', title)))
+        title = item_data.get('episodeTitle')
+        plot = '\n'.join((loc_time.strftime(time_fmt), item_data.get('synopsis', title)))
 
         # Does paid news exists?
-        if news_item.get('isPaid'):
+        if item_data.get('isPaid'):
             if hide_paid:
                 return None
             plot = premium_plot(plot)
@@ -252,13 +270,13 @@ def parse_news_collection_item(news_item, time_zone, time_fmt, hide_paid=False):
             'type': 'title',
             'show': {
                 'label': title,
-                'art': {'thumb': news_item['imageUrl'].format(**IMG_PROPS_THUMB)},
-                'info': {'plot': plot, 'sorttitle': sort_title(title), 'duration': news_item.get('duration')},
-                'params': {'url': url }
+                'art': {'thumb': item_data['imageUrl'].format(**IMG_PROPS_THUMB)},
+                'info': {'plot': plot, 'sorttitle': sort_title(title), 'duration': item_data.get('duration')},
+                'params': {'url': url}
             }
         }
-    except Exception:
-        logger.warning("Failed to parse news_collection_item:\n%s", json.dumps(news_item, indent=4))
+    except Exception as err:
+        logger.error("Unexpected error parsing a shortForm item: %r\n%s", err, json.dumps(item_data, indent=4))
         return None
 
 

--- a/test/local/test_itvx.py
+++ b/test/local/test_itvx.py
@@ -121,50 +121,50 @@ class MainPageItem(TestCase):
 class Collections(TestCase):
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
     def test_collection_news(self, _):
-        items = itvx.collection_content(slider='shortFormSliderContent')
+        items = list(filter(None, itvx.collection_content(slider='shortFormSliderContent')))
         self.assertGreater(len(items), 10)
         for item in items:
             has_keys(item, 'type', 'show')
-        items2 = itvx.collection_content(slider='shortFormSliderContent', hide_paid=True)
+        items2 = list(filter(None, itvx.collection_content(slider='shortFormSliderContent', hide_paid=True)))
         self.assertListEqual(items, items2)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
     def test_collection_trending(self, _):
-        items = itvx.collection_content(slider='trendingSliderContent')
+        items = list(filter(None, itvx.collection_content(slider='trendingSliderContent')))
         self.assertGreater(len(items), 10)
         for item in items:
             has_keys(item, 'type', 'show')
-        items2 = itvx.collection_content(slider='trendingSliderContent', hide_paid=True)
+        items2 = list(filter(None, itvx.collection_content(slider='trendingSliderContent', hide_paid=True)))
         self.assertListEqual(items, items2)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
     def test_collection_from_main_page(self, _):
-        items = itvx.collection_content(slider='editorialRailSlot1')
+        items = list(itvx.collection_content(slider='editorialRailSlot1'))
         self.assertGreater(len(items), 10)
         for item in items:
             has_keys(item, 'type', 'show')
-        items2 = itvx.collection_content(slider='editorialRailSlot1', hide_paid=True)
+        items2 = list(filter(None, itvx.collection_content(slider='editorialRailSlot1', hide_paid=True)))
         self.assertListEqual(items, items2)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('json/editorial_slider.json'))
     def test_collection_from_test_rail(self, _):
         """Test a specially crafted slider with all possible types of items."""
-        items = itvx.collection_content(slider='testRailSlot1')
+        items = list(filter(None, itvx.collection_content(slider='testRailSlot1')))
         self.assertEqual(len(items), 8)
         for item in items:
             has_keys(item, 'type', 'show')
         self.assertTrue(items[7]['type'] == 'collection')
-        items2 = itvx.collection_content(slider='testRailSlot1', hide_paid=True)
+        items2 = list(filter(None, itvx.collection_content(slider='testRailSlot1', hide_paid=True)))
         self.assertListEqual(items, items2)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
     def test_non_existing_collection_from_main_page(self, _):
-        items = itvx.collection_content(slider='SomeNonExistingSlider')
+        items = list(filter(None, itvx.collection_content(slider='SomeNonExistingSlider')))
         self.assertListEqual([], items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/collection_just-in_data.json'))
     def test_collection_from_collection_page(self, _):
-        items = itvx.collection_content(url='collection_top_picks')
+        items = list(itvx.collection_content(url='collection_top_picks'))
         self.assertGreater(len(items), 10)
         for item in items:
             has_keys(item, 'type', 'show')
@@ -173,17 +173,28 @@ class Collections(TestCase):
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/collection_itvx-kids.json'))
     def test_collection_from_collection_page_with_rails(self, _):
-        items = itvx.collection_content(url='itvx_kids')
+        items = list(itvx.collection_content(url='itvx_kids'))
         self.assertGreater(len(items), 10)
         for item in items:
             has_keys(item, 'type', 'show')
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/collection_itvx-fast.json'))
     def test_collection_of_live_fast_channels(self, _):
-        items = itvx.collection_content(url='itvx_fast')
+        items = list(itvx.collection_content(url='itvx_fast'))
         self.assertEqual(3, len(items))
         for item in items:
             has_keys(item, 'type', 'show')
+
+    def test_collection_with_shortform_slider(self):
+        page_data = open_json('json/test_collection.json')
+        page_data['collection'] = None
+        with patch('resources.lib.itvx.get_page_data', return_value=page_data):
+            items = list(itvx.collection_content(url='https://www.itvx_coll'))
+            self.assertEqual(2, len(items))
+            for item in items:
+                has_keys(item, 'type', 'show')
+                is_li_compatible_dict(self, item['show'])
+
 
     @patch('resources.lib.itvx.get_page_data', side_effect=(open_json('html/collection_the-costume-collection.json'),
                                                             open_json('html/collection_the-costume-collection.json')))
@@ -191,15 +202,15 @@ class Collections(TestCase):
         # The costume collection has 18 show, 1 title, of which 3 are premium
         items = list(itvx.collection_content(url='the_costume_collection'))
         self.assertEqual(19, len(items))
-        items = itvx.collection_content(url='the_costume_collection', hide_paid=True)
+        items = list(filter(None, itvx.collection_content(url='the_costume_collection', hide_paid=True)))
         self.assertEqual(16, len(items))
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/collection_just-in_data.json'))
     @patch('resources.lib.parsex.parse_collection_item', return_value=None)
     def test_collection_with_invalid_items(self, _, __):
         """Items that fail to parse return None and must be filtered out in the final result."""
-        items = itvx.collection_content(url='some/url')
-        self.assertListEqual([], items)
+        items = list(itvx.collection_content(url='some/url'))
+        self.assertListEqual([None] * 113, items)
 
 class Categories(TestCase):
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/categories_data.json'))

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -72,16 +72,24 @@ class Generic(unittest.TestCase):
         item = {'contentType': 'special', 'title': False}
         self.assertIsNone(parsex.parse_hero_content(item))
 
-    def test_parse_short_form_slider(self):
+    def test_parse_main_page_short_form_slider(self):
         data = open_json('html/index-data.json')
         for slider in data['shortFormSliderContent']:
             obj = parsex.parse_short_form_slider(slider)
             has_keys(obj, 'type', 'show')
             is_li_compatible_dict(self, obj['show'])
+            self.assertFalse('slider' in obj['show']['params'])
         # Return None on parse errors
         self.assertIsNone(parsex.parse_short_form_slider([]))
         # Return None when a 'view all items' link to collection page is absent from the header
         self.assertIsNone(parsex.parse_short_form_slider({'header': {}}))
+
+    def test_parse_collection_short_form_slider(self):
+        data = open_json('json/test_collection.json')
+        obj = parsex.parse_short_form_slider(data['shortFormSlider'], url='https://mypage')
+        has_keys(obj, 'type', 'show')
+        is_li_compatible_dict(self, obj['show'])
+        self.assertEqual('shortFormSlider', obj['show']['params']['slider'])
 
     def test_parse_editorial_slider(self):
         data = open_json('html/index-data.json')
@@ -130,22 +138,30 @@ class Generic(unittest.TestCase):
         has_keys(item, 'type', 'show')
         is_li_compatible_dict(self, item['show'])
 
-    def test_parse_news_collection_item(self):
-        data = open_json('html/index-data.json')['shortFormSliderContent'][0]['items']
+
+    def test_parse_shortform_item(self):
         tz_uk = pytz.timezone('Europe/London')
-        # a short new item
-        item = parsex.parse_news_collection_item(data[1], tz_uk, "%H-%M-%S")
+
+        # ShortForm from collection
+        data = open_json('json/test_collection.json')
+        sf_item = data['shortFormSlider']['items'][0]
+        obj = parsex.parse_shortform_item(sf_item, tz_uk, "%H-%M-%S")
+        self.assertEqual('title', obj['type'])
+        is_li_compatible_dict(self, obj['show'])
+
+        # an item like a normal catchup episode
+        item = parsex.parse_shortform_item(data['shortFormSlider']['items'][0], tz_uk, "%H-%M-%S")
         has_keys(item, 'type', 'show')
         is_li_compatible_dict(self, item['show'])
-        # NOTE: As of 20-7-23 all news collection item appear to have the same structure
-        #       Just need to test a bit longer to be sure.
-        # a new item like a normal catchup episode
-        # item = parsex.parse_news_collection_item(data[-1], tz_uk, "%H-%M-%S")
-        # has_keys(item, 'playable', 'show')
-        # is_li_compatible_dict(self, item['show'])
+
+        # shortForm news item from the main page
+        data = open_json('html/index-data.json')['shortFormSliderContent'][0]['items']
+        item = parsex.parse_shortform_item(data[1], tz_uk, "%H-%M-%S")
+        has_keys(item, 'type', 'show')
+        is_li_compatible_dict(self, item['show'])
 
         # An invalid item
-        item = parsex.parse_news_collection_item({}, None, None)
+        item = parsex.parse_shortform_item({}, None, None)
         self.assertIsNone(item)
 
 

--- a/test/test_docs/json/test_collection.json
+++ b/test/test_docs/json/test_collection.json
@@ -1,0 +1,242 @@
+{
+  "headingTitle": "Rugby World Cup",
+  "headingDescription": "Stream all the latest and classic matches for free",
+  "pageImageUrl": "https://ovp.itv.com/images/content-partner-banner/rugbyworldcup/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+  "collection": null,
+  "editorialSliders": [
+    {
+      "containerType": "Rail",
+      "displayType": "Standard",
+      "id": "zyqPJaRe6vOFftNzu4HY8",
+      "collection": {
+        "headingTitle": "Don't miss a moment...",
+        "headingLink": {
+          "href": "/collections/dont-miss-a-moment/3ctGv6rzQ2etzrAmPOvWsh",
+          "text": "View All"
+        },
+        "sliderName": "editorial_rail_slot1",
+        "itemCount": 38,
+        "shows": [
+          {
+            "imagePresets": {},
+            "contentType": "simulcastspot",
+            "title": "Rugby World Cup 2023: Ireland v Scotland",
+            "channel": "itv",
+            "tagNames": [
+              "live"
+            ],
+            "description": "Ireland v Scotland",
+            "contentInfo": "19:15-22:20",
+            "genre": "Sport",
+            "startDateTime": "2023-10-07T18:15:00Z",
+            "endDateTime": "2023-10-07T21:20:00Z",
+            "progress": 41,
+            "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/rwcirlvsco/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+          },
+          {
+            "imagePresets": {},
+            "contentType": "fastchannelspot",
+            "title": "Rugby World Cup Classics",
+            "channel": "fast13",
+            "tagNames": [
+              "live"
+            ],
+            "description": "Classic matches, 24/7",
+            "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-rugbyworldcup/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+          },
+          {
+            "imagePresets": {},
+            "contentType": "series",
+            "title": "Grand Slammers: Inside HMP The Mount",
+            "channel": "itv",
+            "ccid": "k4pc5j1",
+            "description": "Rugby goes behind bars - can these sporting legends recreate history? ",
+            "isPaid": false,
+            "episodeId": "10/4742/0001",
+            "programmeId": "10/4742",
+            "encodedEpisodeId": {
+              "letterA": "10a4742a0001",
+              "underscore": "10_4742_0001"
+            },
+            "encodedProgrammeId": {
+              "letterA": "10a4742",
+              "underscore": "10_4742"
+            },
+            "titleSlug": "grand-slammers-inside-hmp-the-mount",
+            "dateTime": "2023-10-03T21:45:00Z",
+            "categories": [
+              "FACTUAL"
+            ],
+            "seriesNumber": 1,
+            "contentInfo": "Series 1",
+            "series": [
+              {
+                "seriesNumber": 1
+              }
+            ],
+            "imageTemplate": "https://ovp.itv.com/images/series/k4pc5j1/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+          },
+          {
+            "imagePresets": {},
+            "contentType": "episode",
+            "title": "Rugby World Cup 2023 Highlights",
+            "channel": "itv",
+            "ccid": "tkc3ff2",
+            "description": "All the best bits!",
+            "isPaid": false,
+            "episodeId": "10/4850/0035",
+            "programmeId": "10/4850",
+            "encodedEpisodeId": {
+              "letterA": "10a4850a0035",
+              "underscore": "10_4850_0035"
+            },
+            "encodedProgrammeId": {
+              "letterA": "10a4850",
+              "underscore": "10_4850"
+            },
+            "titleSlug": "rugby-world-cup-2023-highlights",
+            "categories": [
+              "SPORT"
+            ],
+            "seriesNumber": 1,
+            "episodeNumber": 35,
+            "episodeTitle": "Wales v Georgia (Group Stages) - 7 Oct",
+            "contentInfo": "S1, E35. Wales v Georgia (Group Stages) - 7 Oct",
+            "imageTemplate": "https://ovp.itv.com/images/episode/tkc3ff2/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+          },
+          {
+            "imagePresets": {},
+            "contentType": "brand",
+            "title": "SailGP 2023/24",
+            "channel": "itv",
+            "ccid": "yzqyd1g",
+            "description": "High-octane action - ten international teams compete in identical boats",
+            "isPaid": false,
+            "episodeId": "10/4771/0008",
+            "programmeId": "10/4771",
+            "encodedEpisodeId": {
+              "letterA": "10a4771a0008",
+              "underscore": "10_4771_0008"
+            },
+            "encodedProgrammeId": {
+              "letterA": "10a4771",
+              "underscore": "10_4771"
+            },
+            "titleSlug": "sailgp-202324",
+            "categories": [
+              "SPORT"
+            ],
+            "numberOfAvailableSeries": 1,
+            "contentInfo": "Series 1",
+            "imageTemplate": "https://ovp.itv.com/images/programme/yzqyd1g/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+          },
+          {
+            "imagePresets": {},
+            "contentType": "special",
+            "title": "England's Grand",
+            "channel": "itv",
+            "ccid": "q7qlkcc",
+            "description": "Gareth Southgate, Harry Kane & more celebrate England 1,000th match",
+            "isPaid": false,
+            "episodeId": "2/7654/0001",
+            "programmeId": "2/7654",
+            "encodedEpisodeId": {
+              "letterA": "2a7654a0001",
+              "underscore": "2_7654_0001"
+            },
+            "encodedProgrammeId": {
+              "letterA": "2a7654",
+              "underscore": "2_7654"
+            },
+            "titleSlug": "englands-grand",
+            "dateTime": "2020-11-10T23:45:00Z",
+            "categories": [
+              "SPORT"
+            ],
+            "duration": "PT1H30M",
+            "contentInfo": "1h 30m",
+            "imageTemplate": "https://ovp.itv.com/images/special/q7qlkcc/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+          },
+          {
+            "imagePresets": {},
+            "contentType": "film",
+            "title": "This Sporting Life",
+            "channel": "itv2",
+            "ccid": "6v54nq5",
+            "description": "Richard Harris is remarkable as a miner who wants to quit his job",
+            "isPaid": false,
+            "episodeId": "CFD0696/0001",
+            "programmeId": "CFD0696",
+            "encodedEpisodeId": {
+              "letterA": "CFD0696a0001",
+              "underscore": "CFD0696_0001"
+            },
+            "encodedProgrammeId": {
+              "letterA": "CFD0696",
+              "underscore": "CFD0696"
+            },
+            "titleSlug": "this-sporting-life",
+            "categories": [
+              "FILMS"
+            ],
+            "duration": "PT2H10M",
+            "contentInfo": "2h 10m",
+            "imageTemplate": "https://ovp.itv.com/images/film/6v54nq5/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+          }
+        ],
+        "isChildrenCollection": false
+      }
+    }
+  ],
+  "shortFormSlider": {
+    "header": {
+      "title": "Rugby World Cup 2023"
+    },
+    "items": [
+      {
+        "imagePresets": {},
+        "episodeTitle": "Ireland fast out of the traps against Scotland",
+        "episodeId": "8qcqkf3",
+        "titleSlug": "ireland-fast-out-of-the-traps-against-scotland",
+        "imageUrl": "https://images.ctfassets.net/zkw1wfs2si3w/4D7T3zPffEVecnBx0g8ypg/b28cca6f9a19fb68b2575e7828df2231/LOWE_TRY_IRL.png?w={width}&h={height}&q={quality}&fm={image_format}",
+        "synopsis": "James Lowe races in for the first try of the evening!",
+        "dateTime": "2023-10-07T19:14:01.185Z",
+        "duration": 83,
+        "posterImage": "https://images.ctfassets.net/zkw1wfs2si3w/2567qDAyWPMPI8lwN6RK8E/7bad58785fac58ce184695781cf7fabf/lowe_try_irl.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "genre": "sport",
+        "href": "/watch/sport/undefined"
+      },
+      {
+        "imagePresets": {},
+        "episodeTitle": "Full Match: Ireland v Scotland",
+        "encodedEpisodeId": {"letterA": "2a4138a0037", "underscore": "2_4138_0037"},
+        "encodedProgrammeId": {"letterA": "2a4138", "underscore": "2_4138"},
+        "titleSlug": "full-match-ireland-v-scotland",
+        "programmeTitle": "Rugby World Cup",
+        "episodeId": "2/4138/0037",
+        "programmeId": "2/4138",
+        "imageUrl": "https://images.ctfassets.net/zkw1wfs2si3w/7AjUyh0LGctJ2RpAyukwpO/9d4310b3044e786a5b56c1e4a396c07c/RWC-2023-Live-Match-Pool-IRL-V-SCO_05_TabletMobile_RailTileLandscape_WithLogo_1920x1080.jpg?w={width}&h={height}&q={quality}&fm={image_format}",
+        "dateTime": "2023-10-08T10:47:39.946Z",
+        "genre": "sport",
+        "href": "/watch/sport/undefined"
+      }
+    ],
+    "key": "sportShortForm",
+    "genre": "sport",
+    "isRail": true,
+    "dataTestId": "sport-rail",
+    "tileType": "news",
+    "trackingProps": {
+      "contentType": "news clip"
+    }
+  },
+  "navAdServerParams": {
+    "area": "collections",
+    "category": [],
+    "appname": "dotcom",
+    "appversion": "2.127.2",
+    "size": "hubsponsorbutton"
+  },
+  "collectionSlug": "rugby-world-cup",
+  "isAccessibleByKids": false
+}

--- a/test/web/test_itvx.py
+++ b/test/web/test_itvx.py
@@ -53,7 +53,7 @@ class TestItvX(unittest.TestCase):
             result = list(itvx.category_content(cat['params']['path']))
             self.assertGreater(len(result), 1)      # News has only a few items
             for item in result:
-                self.assertIsInstance(item['playable'], bool)
+                self.assertTrue(item['type'] in ('series', 'brand', 'programme', 'episode', 'special', 'film', 'title'))
                 is_li_compatible_dict(self, item['show'])
 
     def test_category_news(self):

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -38,7 +38,7 @@ class TestMenu(unittest.TestCase):
         self.assertAlmostEqual(len(items), 8, delta=2)
 
     def test_menu_collections(self):
-        items = main.list_collections(MagicMock())
+        items = main.list_collections.test()
         self.assertIsInstance(items, list)
         self.assertAlmostEqual(len(items), 20, delta=4)
 


### PR DESCRIPTION
Show a folder with (mostly) short news-like clips in collections. 
The existince of such a folder is probably a rare occurance, but at this moment the collection 'Rugby World Cup' has a folder that contains short news clips.