### PR TITLE
Support items of type simulcastspot in collections

### DIFF
--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -184,7 +184,7 @@ def parse_collection_item(show_data, hide_paid=False):
     # noinspection PyBroadException
     try:
         content_type = show_data.get('contentType') or show_data['type']
-        is_playable = content_type in ('episode', 'film', 'special', 'title')
+        is_playable = content_type in ('episode', 'film', 'special', 'title', 'fastchannelspot', 'simulcastspot')
         title = show_data['title']
         content_info = show_data.get('contentInfo', '')
 
@@ -207,8 +207,9 @@ def parse_collection_item(show_data, hide_paid=False):
                      'sorttitle': sort_title(title)},
         }
 
-        if content_type == 'fastchannelspot':
+        if content_type in ('fastchannelspot', 'simulcastspot'):
             programme_item['params'] = {'channel': show_data['channel'], 'url': None}
+            # TODO: Enable watch from the start on simulcastspots
         else:
             programme_item['params'] = {'url': build_url(show_data['titleSlug'],
                                         show_data['encodedProgrammeId']['letterA'],

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -128,6 +128,12 @@ class Generic(unittest.TestCase):
         has_keys(item, 'type', 'show')
         is_li_compatible_dict(self, item['show'])
         self.assertEqual('fastchannelspot', item['type'])
+        # simulcastspot
+        data = open_json('json/test_collection.json')['editorialSliders'][0]['collection']['shows']
+        item = parsex.parse_collection_item(data[0])
+        has_keys(item, 'type', 'show')
+        is_li_compatible_dict(self, item['show'])
+        self.assertEqual('simulcastspot', item['type'])
         # An invalid item
         item = parsex.parse_collection_item({})
         self.assertIsNone(item)


### PR DESCRIPTION
Enables collection items refering to one of the reqular live channels.