### PR TITLE
Authenticated requests direct user to settings when authentication fails

### DIFF
--- a/plugin.video.viwx/resources/lib/itv.py
+++ b/plugin.video.viwx/resources/lib/itv.py
@@ -89,48 +89,33 @@ stream_req_data = {
 }
 
 
-def _request_stream_data(url, stream_type='live', retry_on_error=True):
-    from .itv_account import itv_session
+def _request_stream_data(url, stream_type='live'):
+    from .itv_account import itv_session, fetch_authenticated
     session = itv_session()
 
-    try:
-        stream_req_data['user']['token'] = session.access_token
-        stream_req_data['client']['supportsAdPods'] = stream_type != 'live'
+    stream_req_data['user']['token'] = session.access_token
+    stream_req_data['client']['supportsAdPods'] = stream_type != 'live'
 
-        if stream_type == 'live':
-            accept_type = 'application/vnd.itv.online.playlist.sim.v3+json'
-            # Live MUST have a featureset containing an item without outband-webvtt, or a bad request is returned.
-            min_features = ['mpeg-dash', 'widevine']
-        else:
-            accept_type = 'application/vnd.itv.vod.playlist.v2+json'
-            # ITV appears now to use the min feature for catchup streams, causing subtitles
-            # to go missing if not specified here. Min and max both specifying webvtt appears to
-            # be no problem for catchup streams that don't have subtitles.
-            min_features = ['mpeg-dash', 'widevine', 'outband-webvtt', 'hd', 'single-track']
+    if stream_type == 'live':
+        accept_type = 'application/vnd.itv.online.playlist.sim.v3+json'
+        # Live MUST have a featureset containing an item without outband-webvtt, or a bad request is returned.
+        min_features = ['mpeg-dash', 'widevine']
+    else:
+        accept_type = 'application/vnd.itv.vod.playlist.v2+json'
+        # ITV appears now to use the min feature for catchup streams, causing subtitles
+        # to go missing if not specified here. Min and max both specifying webvtt appears to
+        # be no problem for catchup streams that don't have subtitles.
+        min_features = ['mpeg-dash', 'widevine', 'outband-webvtt', 'hd', 'single-track']
 
-        stream_req_data['variantAvailability']['featureset']['min'] = min_features
+    stream_req_data['variantAvailability']['featureset']['min'] = min_features
 
-        stream_data = fetch.post_json(
-            url, stream_req_data,
-            headers={'Accept': accept_type},
-            cookies=session.cookie)
+    stream_data = fetch_authenticated(
+        fetch.post_json, url,
+        data=stream_req_data,
+        headers={'Accept': accept_type},
+        cookies=session.cookie)
 
-        http_status = stream_data.get('StatusCode', 0)
-        if http_status == 401:
-            raise AuthenticationError
-
-        return stream_data
-    except AuthenticationError:
-        if retry_on_error:
-            if session.refresh():
-                return _request_stream_data(url, stream_type, retry_on_error=False)
-            else:
-                if kodi_utils.show_msg_not_logged_in():
-                    from xbmc import executebuiltin
-                    executebuiltin('Addon.OpenSettings({})'.format(utils.addon_info.id))
-                raise
-        else:
-            raise
+    return stream_data
 
 
 def get_live_urls(url=None, title=None, start_time=None, play_from_start=False):

--- a/plugin.video.viwx/resources/lib/itv.py
+++ b/plugin.video.viwx/resources/lib/itv.py
@@ -19,8 +19,6 @@ from . import utils
 from . import fetch
 from . import kodi_utils
 
-from .errors import AuthenticationError
-
 
 logger = logging.getLogger(logger_id + '.itv')
 

--- a/plugin.video.viwx/resources/lib/itv_account.py
+++ b/plugin.video.viwx/resources/lib/itv_account.py
@@ -4,7 +4,7 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
 # ----------------------------------------------------------------------------------------------------------------------
-
+import sys
 import time
 import os
 import json
@@ -233,22 +233,38 @@ def fetch_authenticated(funct, url, login=True, **kwargs):
 
     for tries in range(2):
         try:
+            access_token = account.access_token
+            auth_cookies = account.cookie
+            if not (access_token and auth_cookies):
+                raise AuthenticationError
+
+            try:
+                if account.account_data['refreshed'] < time.time() - 4 * 3600:
+                    # renew tokens periodically
+                    logger.debug("Token cache time has expired.")
+                    raise AuthenticationError
+            except (KeyError, TypeError):
+                raise AuthenticationError
+
             cookies = kwargs.setdefault('cookies', {})
             headers = kwargs.setdefault('headers', {})
             headers['authorization'] = 'Bearer ' + account.access_token
-            cookies.update(account.cookie)
+            cookies.update(auth_cookies)
             return funct(url=url, **kwargs)
         except AuthenticationError:
-            if tries == 0:
-                logger.debug("Authentication failed on first attempt")
-                if account.refresh() is False:
-                    logger.debug("")
-                    from . import settings
-                    if not (kodi_utils.show_msg_not_logged_in() and settings.login()):
-                        raise
-            else:
+            if tries > 0:
                 logger.warning("Authentication failed on second attempt")
                 raise AccessRestrictedError
+
+            logger.debug("Authentication failed on first attempt")
+            if account.refresh() is False:
+                if login:
+                    if kodi_utils.show_msg_not_logged_in():
+                        from xbmc import executebuiltin
+                        executebuiltin('Addon.OpenSettings({})'.format(utils.addon_info.id))
+                    sys.exit(1)
+                else:
+                    raise
 
 
 def convert_session_data(acc_data: dict) -> dict:

--- a/plugin.video.viwx/resources/lib/itv_account.py
+++ b/plugin.video.viwx/resources/lib/itv_account.py
@@ -24,8 +24,8 @@ SESS_DATA_VERS = 2
 
 class ItvSession:
     def __init__(self):
-        self._user_id = None
-        self._user_nickname = None
+        self._user_id = ''
+        self._user_nickname = ''
         self._expire_time = 0
         self.account_data = {}
         self.read_account_data()

--- a/plugin.video.viwx/resources/lib/kodi_utils.py
+++ b/plugin.video.viwx/resources/lib/kodi_utils.py
@@ -70,6 +70,7 @@ def show_msg_not_logged_in():
             Script.localize(MSG_LOGIN),
             nolabel=Script.localize(BTN_TXT_CANCEL),
             yeslabel=Script.localize(TXT_LOGIN_NOW))
+    logger.debug("Dialog 'Open settings to login' result: {}".format('YES' if result else 'NO' ))
     return result
 
 
@@ -85,7 +86,7 @@ def show_login_result(success: bool, message: str = None):
 
 
 def ask_login_retry(reason):
-    """Show a message that login has failed and ask whether to try again"""
+    """Show a message that login has failed and ask whether to try again."""
 
     if reason.lower() == 'invalid username':
         reason = Script.localize(TXT_INVALID_USERNAME)

--- a/test/local/test_itv.py
+++ b/test/local/test_itv.py
@@ -70,4 +70,6 @@ class LiveSchedule(TestCase):
 class RequestStreamData(TestCase):
     def test_request_with_auth_failure(self):
         itv_account.itv_session().log_out()
-        self.assertRaises(errors.AuthenticationError, itv._request_stream_data, 'some/url')
+        with self.assertRaises(SystemExit) as cm:
+            itv._request_stream_data('some/url')
+        self.assertEqual(1, cm.exception.code)

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -319,8 +319,9 @@ class PlayStreamLive(TestCase):
     def test_play_stream_live_without_credentials(self, _):
         itv_account.itv_session().log_out()
         itv_account._itv_session_obj = None
-        result = main.play_stream_live.test(channel='ITV', url=None)
-        self.assertFalse(result)
+        with self.assertRaises(SystemExit) as cm:
+            main.play_stream_live.test(channel='ITV', url=None)
+        self.assertEqual(1, cm.exception.code)
 
 
 class PlayStreamCatchup(TestCase):
@@ -383,8 +384,9 @@ class PlayStreamCatchup(TestCase):
     def test_play_catchup_without_credentials(self, _):
         # Ensure we have an empty file and session object
         itv_account.itv_session().log_out()
-        result = main.play_stream_catchup.test('url', '')
-        self.assertFalse(result)
+        with self.assertRaises(SystemExit) as cm:
+            main.play_stream_catchup.test('url', '')
+        self.assertEqual(1, cm.exception.code)
 
 
 class PlayTitle(TestCase):

--- a/test/web/test_itv_account.py
+++ b/test/web/test_itv_account.py
@@ -4,18 +4,17 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
 # ----------------------------------------------------------------------------------------------------------------------
-import json
-import time
-
-from support import testutils
 from test.support import fixtures
 fixtures.global_setup()
 
+import json
+import time
 import binascii
 import unittest
 from unittest.mock import patch
 
 from resources.lib import itv_account
+from test.support import testutils
 from test.support import object_checks
 from test.local.test_account import ACCESS_TKN_FIELDS, REFRESH_TKN_FIELDS, PROFILE_TKN_FIELDS
 
@@ -45,7 +44,6 @@ class TestLogin(unittest.TestCase):
 
 class TestTokens(unittest.TestCase):
     @classmethod
-    @patch("resources.lib.kodi_utils.ask_credentials", new=lambda x, y: (x, y))
     def setUpClass(cls) -> None:
         cls.itv_sess = sess = itv_account.itv_session()
         # Fetch the tokens

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -62,7 +62,7 @@ class TestMyItvx(unittest.TestCase):
 
     def test_continue_watching_not_signed_in(self):
         with patch.object(itv_account._itv_session_obj, 'account_data', new={}):
-            self.assertRaises(errors.AuthenticationError, main.list_last_watched.test, filter_char=None)
+            self.assertRaises(SystemExit, main.list_last_watched.test, filter_char=None)
 
 
 class TstCategories(unittest.TestCase):


### PR DESCRIPTION
If an authenticated request fails a dialog is now presented offering the user to open settings and the script exists afterwards, rather than trying the same request again after successfull login. Most authenticated requests need some valid account data in the request, so doing the same request again will hardly ever succeed.