### PR TITLE
Add feature 'My List'

### DIFF
--- a/plugin.video.viwx/resources/lib/cache.py
+++ b/plugin.video.viwx/resources/lib/cache.py
@@ -27,6 +27,9 @@ DFLT_EXPIRE_TIME = 600
 __cache = {}
 
 
+my_list_programmes = None
+
+
 def get_item(key):
     """Return the cached data if present in the cache and not expired.
     Return None otherwise.

--- a/plugin.video.viwx/resources/lib/fetch.py
+++ b/plugin.video.viwx/resources/lib/fetch.py
@@ -261,6 +261,20 @@ def put_json(url, data, headers=None, **kwargs):
     return resp
 
 
+def delete_json(url, data, headers=None, **kwargs):
+    """DELETE JSON data and return the response object or None if no data has been returned."""
+    dflt_headers = {'Accept': 'application/json'}
+    if headers:
+        dflt_headers.update(headers)
+    resp = web_request('DELETE', url, dflt_headers, data, **kwargs)
+    if resp.status_code == 204:     # No Content
+        return None
+    try:
+        return resp.json()
+    except json.JSONDecodeError:
+        raise FetchError(Script.localize(30920))
+
+
 def get_document(url, headers=None, **kwargs):
     """GET any document. Expects the document to be UTF-8 encoded and returns
     the contents as string.

--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -485,6 +485,13 @@ def search(search_term, hide_paid=False):
     return (parsex.parse_search_result(result) for result in results)
 
 
+def get_mylist(user_id):
+    url = 'https://my-list.prd.user.itv.com/user/{}/mylist?features={}&platform={}'.format(
+        user_id, FEATURE_SET, PLATFORM_TAG)
+    # Requesting content-type application/json returns a list instead of a dict
+    my_list = itv_account.fetch_authenticated(fetch.get_json, url)
+    return [parsex.parse_my_list_item(item) for item in my_list]
+
 def get_last_watched():
     cache_key = 'last_watched'
     cached_data = cache.get_item(cache_key)

--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -251,7 +251,7 @@ def episodes(url, use_cache=False):
     if use_cache:
         cached_data = cache.get_item(url)
         if cached_data is not None:
-            return cached_data
+            return cached_data['series_map'], cached_data['programme_id']
 
     page_data = get_page_data(url, cache_time=0)
     try:
@@ -259,6 +259,7 @@ def episodes(url, use_cache=False):
     except KeyError:
         logger.warning("Trying to parse episodes in legacy format for programme %s", url)
         return legacy_episodes(url)
+    programme_id = programme.get('encodedProgrammeId', {}).get('underscore')
     programme_title = programme['title']
     programme_thumb = programme['image'].format(**parsex.IMG_PROPS_THUMB)
     programme_fanart = programme['image'].format(**parsex.IMG_PROPS_FANART)
@@ -270,7 +271,7 @@ def episodes(url, use_cache=False):
 
     series_data = page_data.get('seriesList')
     if not series_data:
-        return {}
+        return {}, None
 
     # The field 'seriesNumber' is not guaranteed to be unique - and not guaranteed an integer either.
     # Midsummer murder for instance has 2 series with seriesNumber 4
@@ -296,8 +297,10 @@ def episodes(url, use_cache=False):
             })
         series_obj['episodes'].extend(
             [parsex.parse_episode_title(episode, programme_fanart) for episode in series['titles']])
-    cache.set_item(url, series_map, expire_time=1800)
-    return series_map
+
+    programme_data = {'programme_id': programme_id, 'series_map': series_map}
+    cache.set_item(url, programme_data, expire_time=1800)
+    return series_map, programme_id
 
 
 def legacy_episodes(url):
@@ -344,7 +347,7 @@ def legacy_episodes(url):
         series_obj['episodes'].extend(
             [parsex.parse_legacy_episode_title(episode, brand_fanart) for episode in series['episodes']])
     cache.set_item(url, series_map, expire_time=1800)
-    return series_map
+    return series_map, None
 
 
 def categories():
@@ -485,12 +488,36 @@ def search(search_term, hide_paid=False):
     return (parsex.parse_search_result(result) for result in results)
 
 
-def get_mylist(user_id):
-    url = 'https://my-list.prd.user.itv.com/user/{}/mylist?features={}&platform={}'.format(
-        user_id, FEATURE_SET, PLATFORM_TAG)
-    # Requesting content-type application/json returns a list instead of a dict
-    my_list = itv_account.fetch_authenticated(fetch.get_json, url)
-    return [parsex.parse_my_list_item(item) for item in my_list]
+def my_list(user_id, programme_id=None, operation=None, offer_login=True):
+    """Get itvX's 'My List', or add or remove an item from 'My List' and return the updated list.
+
+    """
+    if operation in ('add', 'remove'):
+        url = 'https://my-list.prd.user.itv.com/user/{}/mylist/programme/{}?features={}&platform={}'.format(
+            user_id, programme_id, FEATURE_SET, PLATFORM_TAG)
+    else:
+        cached_list = cache.get_item('mylist')
+        if cached_list is not None:
+            return cached_list
+        else:
+            url = 'https://my-list.prd.user.itv.com/user/{}/mylist?features={}&platform={}'.format(
+                user_id, FEATURE_SET, PLATFORM_TAG)
+
+    fetcher = {
+        'get': fetch.get_json,
+        'add': fetch.post_json,
+        'remove': fetch.delete_json}.get(operation, fetch.get_json)
+
+    data = itv_account.fetch_authenticated(fetcher, url, data=None, login=offer_login)
+    # Empty lists will return HTTP status 204, which results in data being None
+    if data:
+        my_list_items = [parsex.parse_my_list_item(item) for item in data]
+    else:
+        my_list_items = []
+    cache.set_item('mylist', my_list_items, 1800)
+    cache.my_list_programmes = list(item['programme_id'] for item in my_list_items)
+    return my_list_items
+
 
 def get_last_watched():
     cache_key = 'last_watched'

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -12,13 +12,14 @@ import sys
 
 import pytz
 import requests
+import xbmc
 import xbmcplugin
 from xbmcgui import ListItem
 
 from codequick import Route, Resolver, Listitem, Script, run as cc_run
 from codequick.support import logger_id, build_path, dispatcher
 
-from resources.lib import itv, itvx
+from resources.lib import itv, itv_account, itvx
 from resources.lib import utils
 from resources.lib import parsex
 from resources.lib import fetch
@@ -156,7 +157,11 @@ class Paginator:
 
         for show in shows_list:
             try:
-                yield Listitem.from_dict(callb_map[show['type']], **show['show'])
+                li = Listitem.from_dict(callb_map[show['type']], **show['show'])
+                # Create 'My List' add/remove context menu entries here, so as to be able to update these
+                # entries after adding/removing an item, even when the underlying data is cached.
+                _my_list_context_mnu(li, show.get('programme_id'))
+                yield li
             except KeyError:
                 logger.warning("Cannot list '%s': unknown item type '%s'",
                                show['show'].get('info', {}).get('sorttitle', ''), show['type'])
@@ -179,7 +184,9 @@ def root(_):
     yield Listitem.from_dict(sub_menu_live, 'Live', params={'_cache_to_disc_': False})
     for item in itvx.main_page_items():
         callback = callb_map.get(item['type'], play_title)
-        yield Listitem.from_dict(callback, **item['show'])
+        li = Listitem.from_dict(callback, **item['show'])
+        _my_list_context_mnu(li, item.get('programme_id'))
+        yield li
     yield Listitem.from_dict(list_collections, 'Collections')
     yield Listitem.from_dict(list_categories, 'Categories')
     yield Listitem.search(do_search, Script.localize(TXT_SEARCH))
@@ -192,22 +199,56 @@ def sub_menu_my_itvx(_):
     yield Listitem.from_dict(list_last_watched, 'Continue watching', params={'filter_char': None})
 
 
+def _initialise_my_list():
+    """Get all items from itvX's 'My List'.
+    Used when the module is first imported to initialise the cached list of
+    programme ID's before the plugin lists programmes.
+
+    """
+    try:
+        itvx.my_list(itv_account.itv_session().user_id, offer_login=False)
+        logger.info("Updated MyList programme ID's.")
+    except:
+        # Since this runs before codequick.run() all exceptions must be caught to prevent them
+        # crashing the addon before the main menu is shown.
+        # Most likely the user is not (yet) logged in, but at the start of the addon connection
+        # errors could also occur, depending on the network setup.
+        pass
+
+
+def _my_list_context_mnu(list_item, programme_id):
+    """If `show_item` contains a programme_id, check if the id is in 'My List'
+    and add a context menu to add or remove the item from the list accordingly.
+
+    """
+    if not programme_id:
+        return
+    try:
+        if programme_id in cache.my_list_programmes:
+            list_item.context.script(update_mylist, "Remove from My List", progr_id=programme_id, operation='remove')
+        else:
+            list_item.context.script(update_mylist, "Add to My List", progr_id=programme_id, operation='add')
+    except TypeError:
+        # The cached list of programme ID's is not intialised; do not set a context menu
+        logger.warning("Cannot create 'My List' context menu")
+
+
+
 @Route.register(content_type='videos')
 @dynamic_listing
 def list_my_list(addon, filter_char=None, page_nr=0):
     """List the contents of itvX's 'My List'.
 
     """
-    shows_list = itvx.get_mylist(itv_account.itv_session().user_id)
+    addon.add_sort_methods(xbmcplugin.SORT_METHOD_UNSORTED,
+                           xbmcplugin.SORT_METHOD_TITLE,
+                           xbmcplugin.SORT_METHOD_DATE,
+                           disable_autosort=True)
+    shows_list = itvx.my_list(itv_account.itv_session().user_id)
     logger.info("Listed My List with % items", len(shows_list))
-    # Mylist can contain 999 items,
+    # Mylist can contain 52 items,
     paginator = Paginator(shows_list, filter_char, page_nr)
-    if paginator.is_az_list:
-        yield from paginator
-    else:
-        for li in paginator:
-            li.context.script(update_mylist, "Remove from itvX's My List", li.params['url'])
-            yield li
+    yield from paginator
 
 
 @Route.register(content_type='videos')
@@ -374,9 +415,11 @@ def list_productions(plugin, url, series_idx=None):
                             xbmcplugin.SORT_METHOD_DATE,
                             disable_autosort=True)
 
-    series_map = itvx.episodes(url, use_cache=True)
-    if not series_map:
+    result = itvx.episodes(url, use_cache=True)
+    if not result:
         return
+
+    series_map, programme_id = result
 
     if len(series_map) == 1:
         # List the episodes if there is only 1 series
@@ -400,6 +443,7 @@ def list_productions(plugin, url, series_idx=None):
         # List folders of all series
         for series in series_map.values():
             li = Listitem.from_dict(list_productions, **series['series'])
+            _my_list_context_mnu(li, programme_id)
             yield li
 
 
@@ -410,11 +454,12 @@ def do_search(addon, search_query):
     if not search_results:
         return
 
-    items = [
-        Listitem.from_dict(callb_map.get(result['type'], play_title), **result['show'])
-        for result in search_results if result is not None
-    ]
-    return items
+    for result in search_results:
+        if result is None:
+            continue
+        li = Listitem.from_dict(callb_map.get(result['type'], play_title), **result['show'])
+        _my_list_context_mnu(li, result['programme_id'])
+        yield li
 
 
 def create_dash_stream_item(name: str, manifest_url, key_service_url, resume_time=None):
@@ -595,8 +640,23 @@ def play_title(plugin, url, name=''):
 
 
 @Script.register
-def update_mylist(_, programm_id, operation):
-    pass
+def update_mylist(_, progr_id, operation):
+    """Context menu handler to add or remove a programme from itvX's 'My List'.
+
+    @param str progr_id: The underscore encoded programme ID.
+    @param str operation: The operation to apply; either 'add' or 'remove'.
+
+    """
+    try:
+        itvx.my_list(itv_account.itv_session().user_id, progr_id, operation)
+    except (ValueError, IndexError, FetchError):
+        if operation == 'add':
+            kodi_utils.msg_dlg('Failed to add this item to My List', 'My List Error')
+        else:
+            kodi_utils.msg_dlg('Failed to remove this item from My List', 'My List Error')
+        return
+    logger.info("Updated MyList: %s programme %s", operation, progr_id)
+    xbmc.executebuiltin('Container.Refresh')
 
 
 def run():
@@ -622,3 +682,8 @@ callb_map = {
     'title': play_title,
     'vodstream': play_stream_catchup
 }
+
+
+# Ensure to update the cached list of programmeId's in itvx's My List each time the addon starts.
+if cache.my_list_programmes is None:
+    _initialise_my_list()

--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -520,6 +520,33 @@ def parse_search_result(search_data):
     }
 
 
+def parse_my_list_item(item):
+    progr_name = item['programmeTitle']
+    progr_id = item['programmeId']
+    num_episodes = item['numberOfEpisodes']
+    content_info = ' - {} episodes'.format(num_episodes) if num_episodes is not None else ''
+    img_link = item['itvxImageLink']
+    is_playable = item['contentType'].lower() != 'programme'
+
+    item_dict = {
+        'type': item['contentType'].lower(),
+        'programme_id': progr_id,
+        'show': {
+            'label': progr_name,
+            'art': {'thumb': img_link.format(**IMG_PROPS_THUMB),
+                    'fanart': img_link.format(**IMG_PROPS_FANART)},
+            'info': {'title': progr_name if is_playable else '[B]{}[/B]{}'.format(progr_name, content_info),
+                     'plot': item['synopsis'] if item['tier'] == 'FREE' else premium_plot(item['synopsis']),
+                     'duration': utils.iso_duration_2_seconds(item['duration']),
+                     'sorttitle': sort_title(progr_name),
+                     'date': item['dateAdded']},
+            'params': {'url': build_url(progr_name, progr_id.replace('/', 'a'))}
+        }
+    }
+    if item['contentType'] == 'FILM':
+        item_dict['show']['art']['poster'] = img_link.format(**IMG_PROPS_POSTER)
+    return item_dict
+
 def parse_last_watched_item(item, utc_now):
     progr_name = item.get('programmeTitle', '')
     episode_name = item.get('episodeTitle')

--- a/test/local/test_itvx.py
+++ b/test/local/test_itvx.py
@@ -16,7 +16,7 @@ import time
 import pytz
 
 from test.support.testutils import open_json, open_doc, HttpResponse
-from test.support.object_checks import has_keys, is_li_compatible_dict, is_url
+from test.support.object_checks import has_keys, is_li_compatible_dict, is_url, is_not_empty
 
 from resources.lib import itvx, errors, cache
 
@@ -298,16 +298,17 @@ class Categories(TestCase):
 class Episodes(TestCase):
     @patch('resources.lib.fetch.get_document', new=open_doc('html/series_miss-marple.html'))
     def test_episodes_marple(self):
-        series_listing = itvx.episodes('asd')
+        series_listing, programme_id = itvx.episodes('asd')
         self.assertIsInstance(series_listing, dict)
         self.assertEqual(len(series_listing), 6)
+        self.assertTrue(is_not_empty(programme_id, str))
 
     @patch('resources.lib.fetch.get_document', return_value=open_doc('html/series_miss-marple.html')())
     def test_episodes_with_cache(self, p_fetch):
-        series_listing = itvx.episodes('asd', use_cache=False)
+        series_listing, programme_id = itvx.episodes('asd', use_cache=False)
         self.assertIsInstance(series_listing, dict)
         self.assertEqual(len(series_listing), 6)
-        series_listing = itvx.episodes('asd', use_cache=True)
+        series_listing, programme_id = itvx.episodes('asd', use_cache=True)
         self.assertIsInstance(series_listing, dict)
         self.assertEqual(len(series_listing), 6)
         p_fetch.assert_called_once()
@@ -408,3 +409,19 @@ class GetMyList(TestCase):
     @patch('resources.lib.itv_account.fetch_authenticated', side_effect=SystemExit)
     def test_get_mylist_not_signed_in(self, p_fetch):
         self.assertRaises(SystemExit, itvx.my_list, '156-45xsghf75-4sf569')
+
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
+    def test_add_mylist_item(self, p_fetch):
+        result = itvx.my_list('156-45xsghf75-4sf569', '10_3408', 'add')
+        self.assertEqual(len(list(result)), 4)
+        for item in result:
+            is_li_compatible_dict(self, item['show'])
+        p_fetch.assert_called_once()
+
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
+    def test_remove_mylist_item(self, p_delete):
+        result = itvx.my_list('156-45xsghf75-4sf569', '10_3408', 'remove')
+        self.assertEqual(len(list(result)), 4)
+        for item in result:
+            is_li_compatible_dict(self, item['show'])
+        p_delete.assert_called_once()

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -50,6 +50,8 @@ class MainMenu(TestCase):
         self.assertGreater(len(items), 10)
         for item in items:
             self.assertIsInstance(item, Listitem)
+        # Check 'My I=itvX' is present
+        self.assertTrue(items[0].label == 'My itvX')
 
 
 class LiveChannels(TestCase):
@@ -75,12 +77,36 @@ class LiveChannels(TestCase):
         chans = main.sub_menu_live.test()
         self.assertIsInstance(chans, list)
 
+
 class MyItvx(TestCase):
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('usercontent/last_watched_all.json'))
+    def test_submenu_my_itvx(self, _):
+        list_items = main.sub_menu_my_itvx.test()
+        self.assertEqual(2, len(list_items))
+
     @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('usercontent/last_watched_all.json'))
     @patch('xbmcaddon.Addon.getSettingInt', side_effect=(1000, 50))
     def test_list_last_watched(self, _, __):
         shows = list(main.list_last_watched.route.unittest_caller(filter_char=None))
         self.assertEqual(7, len(shows))
+
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
+    def test_get_my_list(self, _):
+        cache.my_list_programmes = None
+        main._initialise_my_list()
+
+    @patch('resources.lib.itv_account.fetch_authenticated', side_effect=errors.AuthenticationError)
+    def test_get_my_list_not_logged_in(self, _):
+        cache.my_list_programmes = None
+        main._initialise_my_list()
+
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
+    def test_list_mylist(self, _):
+        li_items = main.list_my_list.test(filter_char=None, page_nr=None)
+        self.assertIsInstance(li_items, list)
+        for item in li_items:
+            self.assertIsInstance(item, Listitem)
+
 
 class Collections(TestCase):
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -235,6 +235,13 @@ class Generic(unittest.TestCase):
         search_result['entityType'] = 'dfgs'
         self.assertIsNone(parsex.parse_search_result(search_result))
 
+    def test_parse_mylist(self):
+        data = open_json('mylist/mylist_data.json')['items']
+        for mylist_item in data:
+            item = parsex.parse_my_list_item(mylist_item)
+            has_keys(item, 'type', 'show')
+            is_li_compatible_dict(self, item['show'])
+
     def test_parse_last_watched(self):
         data = open_json('usercontent/last_watched_all.json')
         utc_now = datetime.now(tz=timezone.utc).replace(tzinfo=None)

--- a/test/support/fixtures.py
+++ b/test/support/fixtures.py
@@ -31,6 +31,9 @@ def global_setup():
                          new=lambda self, item: profile_dir if item == 'profile' else '')
         patch_g.start()
 
+        # prevent requesting MyList items at the import of main.
+        patch("resources.lib.cache.my_list_programmes", new=list()).start()
+
         # Enable logging to file during tests with a new file each test run.
         try:
             os.remove(os.path.join(profile_dir, 'addon.log'))

--- a/test/test_docs/mylist/mylist_data.json
+++ b/test/test_docs/mylist/mylist_data.json
@@ -1,6 +1,6 @@
 {
   "totalSize": 4,
-  "availableSlots": 996,
+  "availableSlots": 48,
   "items": [
     {
       "programmeId": "10/0715",

--- a/test/test_docs/mylist/mylist_data.json
+++ b/test/test_docs/mylist/mylist_data.json
@@ -1,0 +1,84 @@
+{
+  "totalSize": 4,
+  "availableSlots": 996,
+  "items": [
+    {
+      "programmeId": "10/0715",
+      "programmeTitle": "Fast and Furious: Hobbs and Shaw",
+      "synopsis": "When the Rock & Jason Statham unite - it\u2019s gonna be a thrill ride!",
+      "channel": "ITV2",
+      "imageLink": "https://ovp.itv.com/images/film/1kt3kp5/itv_hub/04_DesktopCTV_RailTileLandscape/16x9?distributionPartner=itv_hub&fallback=standard&treatment=title&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "itvxImageLink": "https://ovp.itv.com/images/film/1kt3kp5/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "dateAdded": "2023-02-18T23:53:39.973Z",
+      "categories": [
+        "FILM"
+      ],
+      "numberOfEpisodes": null,
+      "tier": "FREE",
+      "duration": "PT2H15M",
+      "numberOfAvailableSeries": [],
+      "longRunning": null,
+      "contentType": "FILM",
+      "contentOwner": null,
+      "partnership": null
+    },
+    {
+      "programmeId": "10/4015",
+      "programmeTitle": "Van Der Valk (Original)",
+      "synopsis": "He's the original - if a tad unconventional - crimestopper",
+      "channel": "ITV",
+      "imageLink": "https://ovp.itv.com/images/programme/hk0jxbs/itv_hub/04_DesktopCTV_RailTileLandscape/16x9?distributionPartner=itv_hub&fallback=standard&treatment=title&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "itvxImageLink": "https://ovp.itv.com/images/programme/hk0jxbs/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "dateAdded": "2023-02-18T01:52:57.750Z",
+      "categories": [
+        "DRAMA_AND_SOAPS"
+      ],
+      "numberOfEpisodes": 32,
+      "tier": "FREE",
+      "duration": null,
+      "numberOfAvailableSeries": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "longRunning": false,
+      "contentType": "PROGRAMME",
+      "contentOwner": null,
+      "partnership": null
+    },
+    {
+      "programmeId": "1/7314",
+      "programmeTitle": "Vera",
+      "synopsis": "Brenda Blethyn is the obsessive crime-cracker DCI Vera Stanhope",
+      "channel": "ITV3",
+      "imageLink": "https://ovp.itv.com/images/programme/mz0gq64/itv_hub/04_DesktopCTV_RailTileLandscape/16x9?distributionPartner=itv_hub&fallback=standard&treatment=title&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "itvxImageLink": "https://ovp.itv.com/images/programme/mz0gq64/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "dateAdded": "2023-02-18T01:42:35.989Z",
+      "categories": [
+        "DRAMA_AND_SOAPS"
+      ],
+      "numberOfEpisodes": 50,
+      "tier": "FREE",
+      "duration": null,
+      "numberOfAvailableSeries": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12
+      ],
+      "longRunning": false,
+      "contentType": "PROGRAMME",
+      "contentOwner": null,
+      "partnership": null
+    }
+  ]
+}

--- a/test/test_docs/mylist/mylist_json_data.json
+++ b/test/test_docs/mylist/mylist_json_data.json
@@ -1,0 +1,102 @@
+[
+  {
+    "programmeId": "10/0715",
+    "programmeTitle": "Fast and Furious: Hobbs and Shaw",
+    "synopsis": "When the Rock & Jason Statham unite - it\u2019s gonna be a thrill ride!",
+    "channel": "ITV2",
+    "imageLink": "https://ovp.itv.com/images/film/1kt3kp5/itv_hub/04_DesktopCTV_RailTileLandscape/16x9?distributionPartner=itv_hub&fallback=standard&treatment=title&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "itvxImageLink": "https://ovp.itv.com/images/film/1kt3kp5/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "dateAdded": "2023-02-18T23:53:39.973Z",
+    "categories": [
+      "FILM"
+    ],
+    "numberOfEpisodes": null,
+    "tier": "FREE",
+    "duration": "PT2H15M",
+    "numberOfAvailableSeries": [],
+    "longRunning": null,
+    "contentType": "FILM",
+    "contentOwner": null,
+    "partnership": null
+  },
+  {
+    "programmeId": "10/3480",
+    "programmeTitle": "The Twelve",
+    "synopsis": "The secret lives of jurors - Sam Neill stars in this twisty thriller",
+    "channel": "ITV",
+    "imageLink": "https://ovp.itv.com/images/programme/8v4lcv1/itv_hub/04_DesktopCTV_RailTileLandscape/16x9?distributionPartner=itv_hub&fallback=standard&treatment=title&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "itvxImageLink": "https://ovp.itv.com/images/programme/8v4lcv1/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "dateAdded": "2023-02-18T23:45:17.991Z",
+    "categories": [
+      "DRAMA_AND_SOAPS"
+    ],
+    "numberOfEpisodes": 10,
+    "tier": "FREE",
+    "duration": null,
+    "numberOfAvailableSeries": [
+      1
+    ],
+    "longRunning": false,
+    "contentType": "PROGRAMME",
+    "contentOwner": null,
+    "partnership": null
+  },
+  {
+    "programmeId": "10/4015",
+    "programmeTitle": "Van Der Valk (Original)",
+    "synopsis": "He's the original - if a tad unconventional - crimestopper",
+    "channel": "ITV",
+    "imageLink": "https://ovp.itv.com/images/programme/hk0jxbs/itv_hub/04_DesktopCTV_RailTileLandscape/16x9?distributionPartner=itv_hub&fallback=standard&treatment=title&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "itvxImageLink": "https://ovp.itv.com/images/programme/hk0jxbs/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "dateAdded": "2023-02-18T01:52:57.750Z",
+    "categories": [
+      "DRAMA_AND_SOAPS"
+    ],
+    "numberOfEpisodes": 32,
+    "tier": "FREE",
+    "duration": null,
+    "numberOfAvailableSeries": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "longRunning": false,
+    "contentType": "PROGRAMME",
+    "contentOwner": null,
+    "partnership": null
+  },
+  {
+    "programmeId": "1/7314",
+    "programmeTitle": "Vera",
+    "synopsis": "Brenda Blethyn is the obsessive crime-cracker DCI Vera Stanhope",
+    "channel": "ITV3",
+    "imageLink": "https://ovp.itv.com/images/programme/mz0gq64/itv_hub/04_DesktopCTV_RailTileLandscape/16x9?distributionPartner=itv_hub&fallback=standard&treatment=title&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "itvxImageLink": "https://ovp.itv.com/images/programme/mz0gq64/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "dateAdded": "2023-02-18T01:42:35.989Z",
+    "categories": [
+      "DRAMA_AND_SOAPS"
+    ],
+    "numberOfEpisodes": 50,
+    "tier": "FREE",
+    "duration": null,
+    "numberOfAvailableSeries": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12
+    ],
+    "longRunning": false,
+    "contentType": "PROGRAMME",
+    "contentOwner": null,
+    "partnership": null
+  }
+]

--- a/test/web/test_itvx.py
+++ b/test/web/test_itvx.py
@@ -15,7 +15,7 @@ from typing import Generator
 
 from codequick import Route
 
-from resources.lib import itvx, errors
+from resources.lib import itvx, errors, itv_account
 from test.support.object_checks import is_url, has_keys, is_li_compatible_dict
 
 setUpModule = fixtures.setup_web_test
@@ -85,3 +85,8 @@ class TestItvX(unittest.TestCase):
         episode_url = "https://www.itv.com/watch/downton-abbey/1a8697/1a8697a0001"
         url = itvx.get_playlist_url_from_episode_page(episode_url)
         self.assertTrue(is_url(url))
+
+    def test_get_mylist(self):
+        uid = itv_account.itv_session().user_id
+        items = itvx.get_mylist(uid)
+        self.assertGreater(len(items), 1)

--- a/test/web/test_itvx.py
+++ b/test/web/test_itvx.py
@@ -88,5 +88,5 @@ class TestItvX(unittest.TestCase):
 
     def test_get_mylist(self):
         uid = itv_account.itv_session().user_id
-        items = itvx.get_mylist(uid)
+        items = itvx.my_list(uid)
         self.assertGreater(len(items), 1)

--- a/test/web/test_itvx_api.py
+++ b/test/web/test_itvx_api.py
@@ -208,7 +208,8 @@ class Search(unittest.TestCase):
                                'synopsis', 'latestAvailableEpisode', 'totalAvailableEpisodes', 'tier',
                                obj_name='programItem.data')
         object_checks.is_url(item_data['latestAvailableEpisode']['imageHref'])
-        self.assertTrue(object_checks.is_encoded_programme_id(item_data['legacyId']['apiEncoded']))
+        self.assertTrue(object_checks.is_not_empty(item_data['legacyId']['apiEncoded'], str))
+        self.assertFalse('/' in item_data['legacyId']['apiEncoded'])
 
     def check_special_item(self, item_data):
         object_checks.has_keys(item_data, 'specialCCId', 'legacyId', 'productionId', 'specialTitle',
@@ -220,22 +221,21 @@ class Search(unittest.TestCase):
         if special_data:
             object_checks.has_keys(special_data, 'programmeCCId', 'legacyId', 'programmeTitle',
                                    obj_name='specialItem.data.specialProgramme')
-            self.assertTrue(object_checks.is_encoded_programme_id(special_data['legacyId']['apiEncoded']))
+            self.assertTrue(object_checks.is_not_empty(special_data['legacyId']['apiEncoded'], str))
+            self.assertFalse('/' in special_data['legacyId']['apiEncoded'])
         else:
-            self.assertTrue(object_checks.is_encoded_programme_id(item_data['legacyId']['apiEncoded']))
+            self.assertTrue(object_checks.is_not_empty(item_data['legacyId']['apiEncoded'], str))
             # Check this programmeId has 2 underscores, since it is in fact more like an episodeId.
             self.assertEqual(2, item_data['legacyId']['apiEncoded'].count('_'))
         object_checks.is_url(item_data['imageHref'])
-
 
     def check_film_item(self, item_data):
         object_checks.has_keys(item_data, 'filmCCId', 'legacyId', 'productionId', 'filmTitle',
                                'synopsis', 'imageHref', 'tier',
                                obj_name='specialItem.data')
         object_checks.is_url(item_data['imageHref'])
-        self.assertTrue(object_checks.is_encoded_programme_id(item_data['legacyId']['apiEncoded']))
-        # Check this programmeId has 2 underscores, since it is in fact more like an episodeId.
-        self.assertEqual(2, item_data['legacyId']['apiEncoded'].count('_'))
+        self.assertTrue(object_checks.is_not_empty(item_data['legacyId']['apiEncoded'], str))
+        self.assertFalse('/' in item_data['legacyId']['apiEncoded'])
 
     def test_search_normal_chase(self):
         self.search_params['query'] = 'the chase'
@@ -371,11 +371,11 @@ class LastWatched(unittest.TestCase):
             object_checks.has_keys(
                 item, 'availabilityEnd', "broadcastDatetime", "contentType", "duration",
                 "episodeNumber", "episodeTitle", "isNextEpisode", "itvxImageLink", "percentageWatched",
-                "productionId", "programmeTitle", "seriesNumber", "synopsis", "tier", "viewedOn",
+                "productionId", "programmeTitle", "seriesNumber", "synopsis", "tier", "viewedOn", "programmeId",
                 obj_name=item['programmeTitle'])
 
             object_checks.expect_keys(item, 'categories', "channel", "channelLink", "contentOwner", "imageLink",
-                                      "episodeId", "programmeId", "longRunning", "partnership",
+                                      "episodeId", "longRunning", "partnership",
                                       obj_name='Watching: {}'.format(item['programmeTitle']))
             self.assertTrue(item['contentType']in ('EPISODE', 'FILM', 'SPECIAL'))
             self.assertTrue(object_checks.is_iso_utc_time(item['availabilityEnd']))
@@ -392,8 +392,8 @@ class LastWatched(unittest.TestCase):
             # tier is usually of type list, but is string here. The parser accepts both
             self.assertTrue(object_checks.is_not_empty(item['tier'], str))
             self.assertTrue(object_checks.is_iso_utc_time(item['viewedOn']))
-
             self.assertTrue(object_checks.is_iso_utc_time(item['availabilityEnd']))
+            self.assertTrue(object_checks.is_not_empty(item['programmeId'], str))
 
             if item['contentType'] == 'EPISODE':
                 # Some episodes' series and/or episode number are None, e.g. episodes of The Chase

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -51,6 +51,18 @@ class TestMyItvx(unittest.TestCase):
     def setUp(self):
         cache.purge()
 
+    def test_mylist(self):
+        items = main.list_my_list(MagicMock(), filter_char=None)
+        self.assertGreater(len(items), 1)
+
+    def test_mylist_wrong_user_id(self):
+        with patch.object(itv_account._itv_session_obj, '_user_id', new=uuid.uuid4()):
+            self.assertRaises(errors.AccessRestrictedError, main.list_my_list.test, filter_char=None)
+
+    def test_my_list_not_signed_in(self):
+        with patch.object(itv_account._itv_session_obj, 'account_data', new={}):
+            self.assertRaises(SystemExit, main.list_my_list.test, filter_char=None)
+
     @patch('xbmcaddon.Addon.getSettingInt', side_effect=(1000, 50))
     def test_continue_watching(self, _):
         items = main.list_last_watched.test(filter_char=None)


### PR DESCRIPTION
Implement ITVX's 'My List'
Use the context menu in various listings to add or remove items from My List.
Only programmes can be added to My List, single episodes cannot. To avoid confusion or false expectations episodes do not have a context menu item to add or remove. The context menu of a series allows adding to My List, but even then the whole programme willl be added.