### PR TITLE
Fix: some issues with new user features related to account sign in/out.

### DIFF
--- a/plugin.video.viwx/resources/lib/itv_account.py
+++ b/plugin.video.viwx/resources/lib/itv_account.py
@@ -53,11 +53,11 @@ class ItvSession:
 
     @property
     def user_id(self):
-        return self._user_id
+        return self._user_id or ''
 
     @property
     def user_nickname(self):
-        return self._user_nickname
+        return self._user_nickname or ''
 
     def read_account_data(self):
         session_file = os.path.join(utils.addon_info.profile, "itv_session")

--- a/plugin.video.viwx/resources/lib/itv_account.py
+++ b/plugin.video.viwx/resources/lib/itv_account.py
@@ -170,6 +170,7 @@ class ItvSession:
         return False
 
     def log_out(self):
+        logger.info("Signing out to ITV account")
         self.account_data = {}
         self.save_account_data()
         self._user_id = None

--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -497,7 +497,7 @@ def my_list(user_id, programme_id=None, operation=None, offer_login=True):
         url = 'https://my-list.prd.user.itv.com/user/{}/mylist/programme/{}?features={}&platform={}'.format(
             user_id, programme_id, FEATURE_SET, PLATFORM_TAG)
     else:
-        cached_list = cache.get_item('mylist')
+        cached_list = cache.get_item('mylist_' + user_id)
         if cached_list is not None:
             return cached_list
         else:
@@ -515,19 +515,20 @@ def my_list(user_id, programme_id=None, operation=None, offer_login=True):
         my_list_items = [parsex.parse_my_list_item(item) for item in data]
     else:
         my_list_items = []
-    cache.set_item('mylist', my_list_items, 1800)
+    cache.set_item('mylist_' + user_id, my_list_items, 1800)
     cache.my_list_programmes = list(item['programme_id'] for item in my_list_items)
     return my_list_items
 
 
 def get_last_watched():
-    cache_key = 'last_watched'
+    user_id = itv_account.itv_session().user_id
+    cache_key = 'last_watched_' + user_id
     cached_data = cache.get_item(cache_key)
     if cached_data is not None:
         return cached_data
 
     url = 'https://content.prd.user.itv.com/lastwatched/user/{}/{}?features={}'.format(
-            itv_account.itv_session().user_id, PLATFORM_TAG, FEATURE_SET)
+            user_id, PLATFORM_TAG, FEATURE_SET)
     header = {'accept': 'application/vnd.user.content.v1+json'}
     utc_now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
     data = itv_account.fetch_authenticated(fetch.get_json, url, headers=header)

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -203,23 +203,6 @@ def sub_menu_my_itvx(_):
     yield Listitem.from_dict(generic_list, 'Recommended for You', params={'list_type':'recommended'})
 
 
-def _initialise_my_list():
-    """Get all items from itvX's 'My List'.
-    Used when the module is first imported to initialise the cached list of
-    programme ID's before the plugin lists programmes.
-
-    """
-    try:
-        itvx.my_list(itv_account.itv_session().user_id, offer_login=False)
-        logger.info("Updated MyList programme ID's.")
-    except:
-        # Since this runs before codequick.run() all exceptions must be caught to prevent them
-        # crashing the addon before the main menu is shown.
-        # Most likely the user is not (yet) logged in, but at the start of the addon connection
-        # errors could also occur, depending on the network setup.
-        pass
-
-
 def _my_list_context_mnu(list_item, programme_id, refresh=True):
     """If `list_item` contains a programme_id, check if the id is in 'My List'
     and add a context menu to add or remove the item from the list accordingly.
@@ -230,7 +213,7 @@ def _my_list_context_mnu(list_item, programme_id, refresh=True):
     try:
         if programme_id in cache.my_list_programmes:
             list_item.context.script(update_mylist, "Remove from My List",
-                                     progr_id=programme_id, operation='remove', refersh=refresh)
+                                     progr_id=programme_id, operation='remove', refresh=refresh)
         else:
             list_item.context.script(update_mylist, "Add to My List",
                                      progr_id=programme_id, operation='add', refresh=refresh)
@@ -669,6 +652,7 @@ callb_map = {
 }
 
 
-# Ensure to update the cached list of programmeId's in itvx's My List each time the addon starts.
-if cache.my_list_programmes is None:
-    _initialise_my_list()
+# A rather hacky method to ensure the cached list of programmeId's in itvx's My List
+# is updated each time the addon starts, but not on settings callbacks.
+if cache.my_list_programmes is None and 'resources/lib/settings' not in sys.argv[0]:
+    itvx.initialise_my_list()

--- a/plugin.video.viwx/resources/lib/settings.py
+++ b/plugin.video.viwx/resources/lib/settings.py
@@ -29,6 +29,7 @@ def login(_=None):
     uname = None
     passw = None
 
+    logger.debug("Starting Login...")
     while True:
         uname, passw = kodi_utils.ask_credentials(uname, passw)
         if not all((uname, passw)):
@@ -37,6 +38,10 @@ def login(_=None):
         try:
             itv_account.itv_session().login(uname, passw)
             kodi_utils.show_login_result(success=True)
+            from resources.lib import itvx
+            import xbmc
+            itvx.initialise_my_list()
+            xbmc.executebuiltin('Container.Refresh')
             return
         except errors.AuthenticationError as e:
             if not kodi_utils.ask_login_retry(str(e)):
@@ -51,6 +56,10 @@ def logout(_):
         Script.notify(Script.localize(kodi_utils.TXT_ITV_ACCOUNT),
                       Script.localize(kodi_utils.MSG_LOGGED_OUT_SUCCESS),
                       Script.NOTIFY_INFO)
+        from resources.lib import cache
+        import xbmc
+        cache.my_list_programmes = None
+        xbmc.executebuiltin('Container.Refresh')
 
 
 @Script.register()

--- a/plugin.video.viwx/resources/settings.xml
+++ b/plugin.video.viwx/resources/settings.xml
@@ -87,7 +87,7 @@
 					<level>0</level>
 					<data>RunPlugin(plugin://$ID/resources/lib/settings/login)</data>
 					<control type="button" format="action">
-						<close>true</close>
+						<close>false</close>
 					</control>
 				</setting>
 				<setting id="account-sign-out" label="30202" type="action" help="30402">

--- a/test/local/test_account.py
+++ b/test/local/test_account.py
@@ -296,6 +296,14 @@ class PropUserId(unittest.TestCase):
         p_login.assert_not_called()
         p_refresh.assert_not_called()
 
+    def test_user_id_after_logout(self, _, __):
+        acc_data = deepcopy(account_data_v2)
+        acc_data['itv_session'] = session_dta['itv_session']
+        with patch('resources.lib.itv_account.open', mock_open(read_data=json.dumps(acc_data))):
+            sess = itv_account.ItvSession()
+        sess.log_out()
+        self.assertEqual('', sess.user_id)
+
 
 @patch('resources.lib.itv_account.ItvSession.login')
 @patch('resources.lib.itv_account.ItvSession.refresh')
@@ -316,6 +324,14 @@ class PropUserNickName(unittest.TestCase):
         self.assertEqual('', sess.user_nickname)
         p_login.assert_not_called()
         p_refresh.assert_not_called()
+
+    def test_user_id_after_logout(self, _, __):
+        acc_data = deepcopy(account_data_v2)
+        acc_data['itv_session'] = session_dta['itv_session']
+        with patch('resources.lib.itv_account.open', mock_open(read_data=json.dumps(acc_data))):
+            sess = itv_account.ItvSession()
+        sess.log_out()
+        self.assertEqual('', sess.user_nickname)
 
 
 class Misc(unittest.TestCase):
@@ -362,9 +378,13 @@ class Misc(unittest.TestCase):
         ct_sess = itv_account.ItvSession()
         p_save.reset_mock()
         ct_sess.account_data = {"some data"}
+        ct_sess._user_id = 'myuserid'
+        ct_sess._user_nickname = 'my-nick'
         ct_sess.log_out()
         self.assertEqual(ct_sess.account_data, {})
         p_save.assert_called_once()
+        self.assertEqual('', ct_sess.user_id)
+        self.assertEqual('', ct_sess.user_nickname)
 
     def test_parse_token(self):
         access_tkn, _, __ = build_test_tokens('My username')

--- a/test/local/test_itvx.py
+++ b/test/local/test_itvx.py
@@ -496,6 +496,25 @@ class GetMyList(TestCase):
         p_delete.assert_called_once()
 
 
+class InitialiseMyList(TestCase):
+    def setUp(self):
+        cache.purge()
+
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
+    def test_initialise_my_list(self, _):
+        itvx.initialise_my_list()
+
+    def test_initialise_my_list_not_logged_in(self):
+        with patch('resources.lib.itv_account.fetch_authenticated', side_effect=errors.AuthenticationError):
+            itvx.initialise_my_list()
+        with patch('resources.lib.itv_account.fetch_authenticated', side_effect=errors.AccessRestrictedError):
+            itvx.initialise_my_list()
+        with patch('resources.lib.itv_account.fetch_authenticated', side_effect=errors.FetchError):
+            itvx.initialise_my_list()
+        with patch('resources.lib.itv_account.fetch_authenticated', side_effect=SystemExit):
+            self.assertRaises(SystemExit, itvx.initialise_my_list)
+
+
 class Recommendations(TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/local/test_itvx.py
+++ b/test/local/test_itvx.py
@@ -328,7 +328,7 @@ class Episodes(TestCase):
         self.assertTrue(is_not_empty(programme_id, str))
 
     @patch('resources.lib.fetch.get_document', return_value=open_doc('html/series_miss-marple.html')())
-    def test_episodes_with_cache(self, p_fetch):
+    def test_episodes_with_cache(self, _):
         series_listing1, programme_id1 = itvx.episodes('asd', use_cache=False)
         self.assertIsInstance(series_listing1, dict)
         self.assertEqual(len(series_listing1), 6)
@@ -467,8 +467,17 @@ class GetMyList(TestCase):
         p_fetch.assert_called_once()
 
     @patch('resources.lib.itv_account.fetch_authenticated', side_effect=SystemExit)
-    def test_get_mylist_not_signed_in(self, p_fetch):
+    def test_get_mylist_not_signed_in(self, _):
         self.assertRaises(SystemExit, itvx.my_list, '156-45xsghf75-4sf569')
+
+    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
+    def test_get_my_list_cache_not_used_after_user_change(self, p_fetch):
+        itvx.my_list('156-45xsghf75-4sf569')
+        p_fetch.assert_called_once()
+        # Check cache is not used with another user ID
+        p_fetch.reset_mock()
+        itvx.my_list('xxx')
+        p_fetch.assert_called_once()
 
     @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
     def test_add_mylist_item(self, p_fetch):

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -102,18 +102,6 @@ class MyItvx(TestCase):
         p_fetch.assert_called_once()
 
     @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
-    def test_initialise_my_list(self, _):
-        main._initialise_my_list()
-
-    def test_initialise_my_list_not_logged_in(self):
-        with patch('resources.lib.itv_account.fetch_authenticated', side_effect=errors.AuthenticationError):
-            main._initialise_my_list()
-        with patch('resources.lib.itv_account.fetch_authenticated', side_effect=errors.AccessRestrictedError):
-            main._initialise_my_list()
-        with patch('resources.lib.itv_account.fetch_authenticated', side_effect=SystemExit):
-            main._initialise_my_list()
-
-    @patch('resources.lib.itv_account.fetch_authenticated', return_value=open_json('mylist/mylist_json_data.json'))
     def test_list_mylist(self, _):
         li_items = main.generic_list.test(filter_char=None, page_nr=None)
         self.assertIsInstance(li_items, list)


### PR DESCRIPTION
Fixes a few errors and peculiarities, amongst which:
- Opening  a list like 'Continue Watching' immediately after a successful sign in triggered the dialog again requesting the user to sign.
- Add/Remove My List items after sign in became only available after opening My List.
- Add/Remove My List items remained available after logout. 
- After logout, or changing user, some lists in My ItvX still showed the content of the previous user.
- The on-screen keyboard to enter username could take a relatively long time to open.