### PR TITLE
Fix: Strip trailing whitespace from URL's

### DIFF
--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -41,6 +41,8 @@ def get_page_data(url, cache_time=None):
     if not url.startswith('https://'):
         url = 'https://www.itv.com' + url
 
+    # URL's with a trailing space have actually happened, but the web app doesn't seem to have a problem with it.
+    url = url.rstrip()
     if cache_time:
         cached_data = cache.get_item(url)
         if cached_data:

--- a/test/web/test_itvx_html.py
+++ b/test/web/test_itvx_html.py
@@ -451,7 +451,8 @@ class CollectionPages(unittest.TestCase):
                     return
                 heading_link = collection_data.get('headingLink')
                 if heading_link:
-                    page_ref = 'https://www.itv.com/watch' + heading_link['href']
+                    # Yes, strip trailing white space. It has actually happened...
+                    page_ref = 'https://www.itv.com/watch' + heading_link['href'].rstrip()
                     if page_ref != url:
                         # Some sliders have a 'view all' reference to their own page.
                         # Which is not so bad on a website and in Kodi, but disastrous in this test.


### PR DESCRIPTION
Fixes some sub-collections fail with fetch Error 'Not Found'.