### PR TITLE
Fix: New URL's for categories

### DIFF
--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -382,7 +382,7 @@ def category_content(url: str, hide_paid=False):
     if cached_data and cached_data['hide_paid'] == hide_paid:
         return cached_data['items_list']
 
-    cat_data = get_page_data(url, cache_time=0)
+    cat_data = get_page_data(url + '/all', cache_time=0)
     category = cat_data['category']['pathSegment']
     progr_list = cat_data.get('programmes')
 

--- a/test/web/test_itvx_html.py
+++ b/test/web/test_itvx_html.py
@@ -648,7 +648,7 @@ class Categories(unittest.TestCase):
             if cat == 'news':
                 # As of May 2023 category news returns a different data structure and has its own test.
                 continue
-            url = 'https://www.itv.com/watch/categories/' + cat
+            url = 'https://www.itv.com/watch/categories/' + cat + '/all'
             t_s = time.time()
             page = fetch.get_document(url)
             t_1 = time.time()


### PR DESCRIPTION
Apart from 'News' all categories now display a set of collections by default. The whole A-Z content as used before is now available on an URL with '/all' added to the path.

Fixes: All categories but 'News' fail to open with TypeError