### PR TITLE
IPTV Manager/Merge support.

### DIFF
--- a/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
@@ -69,6 +69,18 @@ msgctxt "#30121"
 msgid "Offer to play from the start"
 msgstr ""
 
+msgctxt "#30131"
+msgid "Install IPTV Manager"
+msgstr ""
+
+msgctxt "#30132"
+msgid "Enable IPTV Manager integration"
+msgstr ""
+
+msgctxt "#30133"
+msgid "Go to IPTV Manager settings"
+msgstr ""
+
 msgctxt "#30200"
 msgid "itvX account"
 msgstr ""

--- a/plugin.video.viwx/resources/lib/iptvmanager.py
+++ b/plugin.video.viwx/resources/lib/iptvmanager.py
@@ -1,0 +1,28 @@
+
+# ----------------------------------------------------------------------------------------------------------------------
+#  Copyright (c) 2024 Dimitri Kroon.
+#  This file is part of plugin.video.viwx.
+#  SPDX-License-Identifier: GPL-2.0-or-later
+#  See LICENSE.txt
+# ----------------------------------------------------------------------------------------------------------------------
+
+import xbmc
+from codequick.script import Script
+
+
+@Script.register
+def channels(_, port):
+    try:
+        pass
+    except Exception as err:
+        # Catch all errors to prevent codequick showing an error message
+        xbmc.log("[viwX] Error in iptvmanager.channels: {!r}.".format(err))
+
+
+@Script.register
+def epg(_, port):
+    try:
+        pass
+    except Exception as err:
+        # Catch all errors to prevent codequick showing an error message
+        xbmc.log("[viwX] Error in iptvmanager.channels: {!r}.".format(err))

--- a/plugin.video.viwx/resources/lib/iptvmanager.py
+++ b/plugin.video.viwx/resources/lib/iptvmanager.py
@@ -5,15 +5,89 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
 # ----------------------------------------------------------------------------------------------------------------------
-
+import json
+import socket
 import xbmc
+
 from codequick.script import Script
+from codequick.support import build_path
+
+
+# Logo URLs from now/next.
+CHANNELS = {
+    'ITV': {'id': 'viwx.itv',
+            'name': 'ITV',
+            'logo': 'https://images.ctfassets.net/bd5zurrrnk1g/54OefyIkbiHPMJUYApbuUX/7dfe2176762fd8ec10f77cd61a318b07/itv1.png?w=512',
+            'preset': 1},
+    'ITV2': {'id': 'viwx.itv2',
+             'name': 'ITV2',
+             'logo': 'https://images.ctfassets.net/bd5zurrrnk1g/aV9MOsYOMEXHx3iw0p4tk/57b35173231c4290ff199ef8573367ad/itv2.png?w=512',
+             'preset': 2},
+    'ITVBe': {'id': 'viwx.itvbe',
+              'name': 'ITVBe',
+              'logo': 'https://images.ctfassets.net/bd5zurrrnk1g/6Mul5JVrb06pRu8bNDgIAe/b5309fa32322cc3db398d25e523e2b2e/itvBe.png?w=512',
+              'preset': 3},
+    'ITV3': {'id': 'viwx.itv3',
+             'name': 'ITV3',
+             'logo': 'https://images.ctfassets.net/bd5zurrrnk1g/39fJAu9LbUJptatyAs8HkL/80ac6eb141104854b209da946ae7a02f/itv3.png?w=512',
+             'preset': 4},
+    'ITV4': {'id': 'viwx.itv4',
+             'name': 'ITV4',
+             'logo': 'https://images.ctfassets.net/bd5zurrrnk1g/6Dv76O9mtWd6m7DzIavtsf/b3d491289679b8030eae7b4a7db58f2d/itv4.png?w=512',
+             'preset': 5}
+}
+
+
+# IPTVManager class from https://github.com/add-ons/service.iptv.manager/wiki/Integration
+class IPTVManager:
+    """Interface to IPTV Manager"""
+
+    def __init__(self, port):
+        """Initialize IPTV Manager object"""
+        self.port = port
+
+    def via_socket(func):
+        """Send the output of the wrapped function to socket"""
+
+        def send(self):
+            """Decorator to send over a socket"""
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(('127.0.0.1', self.port))
+            try:
+                sock.sendall(json.dumps(func(self)).encode())
+            finally:
+                sock.close()
+
+        return send
+
+    @via_socket
+    def send_channels(self):
+        """Return JSON-STREAMS formatted python datastructure to IPTV Manager"""
+        from resources.lib.main import play_stream_live
+        chan_list = [
+            {
+                'id': chan_data.get('id'),
+                'name': chan_data.get('name'),
+                'logo': chan_data.get('logo'),
+                'stream': build_path(play_stream_live, query={'channel': name, 'url': None})
+            } for name, chan_data in CHANNELS.items()
+        ]
+        return {'version': 1, 'streams': chan_list}
+
+    @via_socket
+    def send_epg(self):
+        """Return JSON-EPG formatted python data structure to IPTV Manager"""
+        from resources.lib.itvx import get_full_schedule
+
+        schedules = get_full_schedule()
+        epg = {CHANNELS[k]['id']: v for k, v in schedules.items()}
+        return dict(version=1, epg=epg)
 
 
 @Script.register
 def channels(_, port):
     try:
-        pass
+        IPTVManager(int(port)).send_channels()
     except Exception as err:
         # Catch all errors to prevent codequick showing an error message
         xbmc.log("[viwX] Error in iptvmanager.channels: {!r}.".format(err))
@@ -22,7 +96,7 @@ def channels(_, port):
 @Script.register
 def epg(_, port):
     try:
-        pass
+         IPTVManager(int(port)).send_epg()
     except Exception as err:
         # Catch all errors to prevent codequick showing an error message
-        xbmc.log("[viwX] Error in iptvmanager.channels: {!r}.".format(err))
+        xbmc.log("[viwX] Error in iptvmanager.epg: {!r}.".format(err))

--- a/plugin.video.viwx/resources/settings.xml
+++ b/plugin.video.viwx/resources/settings.xml
@@ -51,7 +51,45 @@
 				<setting id="live_play_from_start" label="30121" type="boolean" help="30321">
 					<level>0</level>
 					<default>false</default>
+					<control type="toggle" />
+				</setting>
+				<setting id="install_iptvmanager" label="30131" type="action" help="">
+					<level>0</level>
+					<data>InstallAddon(service.iptv.manager)</data>
+					<control type="button" format="action">
+						<close>true</close>
+					</control>
+					<dependencies>
+						<dependency type="visible" on="property" name="infobool" operator="!is">System.HasAddon(service.iptv.manager)</dependency>
+					</dependencies>
+				</setting>
+				<setting id="iptv.enabled" label="30132" type="boolean" help="">
+					<level>0</level>
+					<default>true</default>
 					<control type="toggle"/>
+					<dependencies>
+						<dependency type="visible" on="property" name="infobool">System.HasAddon(service.iptv.manager)</dependency>
+					</dependencies>
+				</setting>
+				<setting id="iptvmanager-settings" label="30133" type="action" help="" parent="iptv.enabled">
+					<data>Addon.OpenSettings(service.iptv.manager)</data>
+					<dependencies>
+						<dependency type="enable" setting="iptv.enabled">true</dependency>
+						<dependency type="visible" on="property" name="infobool">System.HasAddon(service.iptv.manager)</dependency>
+					</dependencies>
+					<control type="button" format="action">
+						<close>true</close>
+					</control>
+				</setting>
+				<setting id="iptv.channels_uri" label="" type="string" help="">
+					<default>plugin://plugin.video.viwx/resources/lib/iptvmanager/channels</default>
+					<visible>false</visible>
+					<control type="edit" format="string" />
+				</setting>
+				<setting id="iptv.epg_uri" label="" type="string" help="">
+					<default>plugin://plugin.video.viwx/resources/lib/iptvmanager/epg</default>
+					<visible>false</visible>
+					<control type="edit" format="string" />
 				</setting>
 			</group>
 			<group id="grp2" label="30110">
@@ -103,4 +141,5 @@
 			</group>
         </category>
     </section>
+
 </settings>

--- a/test/local/test_iptvmanager.py
+++ b/test/local/test_iptvmanager.py
@@ -1,0 +1,89 @@
+# ----------------------------------------------------------------------------------------------------------------------
+#  Copyright (c) 2024 Dimitri Kroon.
+#  This file is part of plugin.video.viwx.
+#  SPDX-License-Identifier: GPL-2.0-or-later
+#  See LICENSE.txt
+# ----------------------------------------------------------------------------------------------------------------------
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from test.support.object_checks import is_not_empty
+from test.support.testutils import open_json
+from resources.lib import iptvmanager
+
+
+class TestIptvmanager(unittest.TestCase):
+    def test_send_channels(self):
+        mocked_socket = MagicMock()
+        mocked_socket.sendall = MagicMock()
+        with patch('socket.socket', return_value=mocked_socket):
+            iptvm = iptvmanager.IPTVManager(port=10)
+            iptvm.send_channels()
+        mocked_socket.sendall.assert_called_once()
+        call_dta = json.loads(mocked_socket.sendall.call_args[0][0])
+        self.assertEqual(1, call_dta['version'])
+        chan_list = call_dta['streams']
+        for chan in chan_list:
+            for key in ('id', 'name', 'logo', 'stream'):
+                self.assertTrue(is_not_empty(chan[key], str))
+
+    def test_send_epg(self):
+        epg_data = {'ITV': [{'start': "23:23", 'end': '12:43', 'title': 'my title', 'description': ''}],
+                    'ITV2': [{'start': "23:23", 'end': '12:43', 'title': 'his title', 'description': ''}],
+                    'ITV3': [{'start': "23:23", 'end': '12:43', 'title': 'm title', 'description': ''}]}
+        mocked_socket = MagicMock()
+        mocked_socket.sendall = MagicMock()
+        with patch('socket.socket', return_value=mocked_socket):
+            with patch('resources.lib.itvx.get_full_schedule', return_value=epg_data):
+                iptvm = iptvmanager.IPTVManager(port=10)
+                iptvm.send_epg()
+
+        mocked_socket.sendall.assert_called_once()
+        call_dta = json.loads(mocked_socket.sendall.call_args[0][0])
+        self.assertEqual(1, call_dta['version'])
+        self.assertListEqual(list(epg_data.values()), list(call_dta['epg'].values()))
+
+    @patch('json.dumps', side_effect=ValueError)
+    def test_send_with_error(self, _):
+        mocked_socket = MagicMock()
+        mocked_socket.sendall = MagicMock()
+        mocked_socket.close = MagicMock()
+        with patch('socket.socket', return_value=mocked_socket):
+            iptvm = iptvmanager.IPTVManager(port=10)
+            self.assertRaises(ValueError, iptvm.send_channels)
+        mocked_socket.sendall.assert_not_called()
+        mocked_socket.close.assert_called()
+
+
+class TestEntryFunctions(unittest.TestCase):
+    @patch('resources.lib.iptvmanager.IPTVManager.send_channels')
+    def test_channels(self, mocked_send_channels):
+        iptvmanager.channels.test(port=1234)
+        mocked_send_channels.assert_called_once()
+
+    @patch('resources.lib.iptvmanager.IPTVManager.send_channels', side_effect=ValueError)
+    def test_channels_with_error(self, _):
+        """Errors should be ignored silently"""
+        iptvmanager.channels.test(port=1234)
+
+    @patch('resources.lib.iptvmanager.IPTVManager.send_epg')
+    def test_epg(self, mocked_send_epg):
+        iptvmanager.epg.test(port=1234)
+        mocked_send_epg.assert_called_once()
+
+    @patch('resources.lib.iptvmanager.IPTVManager.send_epg', side_effect=ValueError)
+    def test_epg_with_error(self, _):
+        """Errors should be ignored silently"""
+        iptvmanager.epg.test(port=1234)
+
+    @patch('resources.lib.itvx.get_page_data', return_value=open_json('schedule/html_schedule.json'))
+    def test_egp_integration(self, _):
+        mocked_socket = MagicMock()
+        mocked_socket.sendall = MagicMock()
+        with patch('socket.socket', return_value=mocked_socket):
+            iptvmanager.epg.test(port=1234)
+        send_data = json.loads(mocked_socket.sendall.call_args[0][0])
+        self.assertEqual(len(send_data['epg']), 5)
+

--- a/test/local/test_itvx.py
+++ b/test/local/test_itvx.py
@@ -105,6 +105,18 @@ class NowNextSchedule(TestCase):
             self.assertEqual('09:20 pm', start_time.lower())
 
 
+class FullSchedule(TestCase):
+    @patch('resources.lib.itvx.get_page_data', return_value=open_json('schedule/html_schedule.json'))
+    def test_full_schedule(self, _):
+        schedules = itvx.get_full_schedule()
+        self.assertIsInstance(schedules, dict)
+        channels = ('ITV', 'ITV2', 'ITVBe', 'ITV3', 'ITV4')
+        has_keys(schedules, *channels)
+        for progr_list in schedules.values():
+            self.assertIsInstance(progr_list, list)
+            self.assertGreater(len(progr_list), 100)
+
+
 class MainPageItem(TestCase):
     def test_list_main_page_items(self):
         page_data = open_json('html/index-data.json')

--- a/test/test_docs/json/schedule_data.json
+++ b/test/test_docs/json/schedule_data.json
@@ -1,0 +1,67 @@
+{
+  "tvGuideData": {
+    "ITV": [
+      {
+        "duration": 5400,
+        "end": "2024-03-10T07:30:00Z",
+        "legacyId": "10/2272/0093#001",
+        "start": "2024-03-10T06:00:00Z",
+        "title": "English Football League Highlights",
+        "ccid": "qwq0xt7",
+        "contentTypeITV": "avod",
+        "genre": "Sport",
+        "episodeNumber": 41,
+        "contentType": "EPISODE",
+        "seriesNumber": null,
+        "description": "All the highlights, action and talking points from the latest English Football League matches.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/english-football-league-highlights/10a2272/10a2272a0093",
+        "programmeLink": "/english-football-league-highlights/10a2272"
+      },
+      {
+        "duration": 6900,
+        "end": "2024-03-10T09:25:00Z",
+        "legacyId": "2/5159/0270#001",
+        "start": "2024-03-10T07:30:00Z",
+        "title": "James Martin's Saturday Morning",
+        "ccid": "jmqbqkw",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 10,
+        "contentType": "EPISODE",
+        "seriesNumber": 7,
+        "description": "The first-class chef hosts his relaxed weekend cookery show from the comfort of his own home. Watch him cook up mouthwatering recipes while chatting to celebrity guests.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/james-martins-saturday-morning/2a5159/2a5159a0270",
+        "programmeLink": "/james-martins-saturday-morning/2a5159"
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T09:30:00Z",
+        "legacyId": "NET10SU24-NN09",
+        "start": "2024-03-10T09:25:00Z",
+        "title": "ITV News Weekend Morning"
+      },
+      {
+        "duration": 900,
+        "end": "2024-03-10T06:40:00Z",
+        "legacyId": "2/3033/0244#001",
+        "start": "2024-03-10T06:25:00Z",
+        "title": "Teen Titans Go!",
+        "ccid": "kxs4kff",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 36,
+        "contentType": "EPISODE",
+        "seriesNumber": 6,
+        "description": "Animated series based on DC Comics' superhero team. Robin, Cyborg, Starfire, Raven and Beast Boy love saving the world. But when they stop fighting crime, things don't go to plan.",
+        "guidance": "With dull moments and scenes that some people may find very boring.",
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/teen-titans-go/2a3033"
+      }
+    ]
+  }
+}

--- a/test/test_docs/schedule/html_schedule.json
+++ b/test/test_docs/schedule/html_schedule.json
@@ -1,0 +1,2292 @@
+{
+  "tvGuideData": {
+    "ITV": [
+      {
+        "duration": 5400,
+        "end": "2024-03-10T07:30:00Z",
+        "legacyId": "10/2272/0093#001",
+        "start": "2024-03-10T06:00:00Z",
+        "title": "English Football League Highlights",
+        "ccid": "qwq0xt7",
+        "contentTypeITV": "avod",
+        "genre": "Sport",
+        "episodeNumber": 41,
+        "contentType": "EPISODE",
+        "seriesNumber": null,
+        "description": "All the highlights, action and talking points from the latest English Football League matches.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/english-football-league-highlights/10a2272/10a2272a0093",
+        "programmeLink": "/english-football-league-highlights/10a2272"
+      },
+      {
+        "duration": 6900,
+        "end": "2024-03-10T09:25:00Z",
+        "legacyId": "2/5159/0270#001",
+        "start": "2024-03-10T07:30:00Z",
+        "title": "James Martin's Saturday Morning",
+        "ccid": "jmqbqkw",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 10,
+        "contentType": "EPISODE",
+        "seriesNumber": 7,
+        "description": "The first-class chef hosts his relaxed weekend cookery show from the comfort of his own home. Watch him cook up mouthwatering recipes while chatting to celebrity guests.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/james-martins-saturday-morning/2a5159/2a5159a0270",
+        "programmeLink": "/james-martins-saturday-morning/2a5159"
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T09:30:00Z",
+        "legacyId": "NET10SU24-NN09",
+        "start": "2024-03-10T09:25:00Z",
+        "title": "ITV News Weekend Morning"
+      },
+      {
+        "duration": 7200,
+        "end": "2024-03-10T11:30:00Z",
+        "legacyId": "10/0437/0129#001",
+        "start": "2024-03-10T09:30:00Z",
+        "title": "Love Your Weekend with Alan Titchmarsh",
+        "ccid": "55yhxjk",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 10,
+        "contentType": "EPISODE",
+        "seriesNumber": 6,
+        "description": "The nation\u2019s favourite gardener Alan Titchmarsh hosts a show celebrating all that is great about the British countryside, including arts, crafts, manufacturing and produce.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/love-your-weekend-with-alan-titchmarsh/10a0437"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T12:30:00Z",
+        "legacyId": "10/3079/0004#001",
+        "start": "2024-03-10T11:30:00Z",
+        "title": "Raymond Blanc's Royal Kitchen Gardens",
+        "ccid": "bm43z4f",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 4,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "World-renowned chef Raymond Blanc uncovers some incredible royal kitchen gardens across the UK, taking in the apple tunnel of Highgrove to Castle of Mey\u2019s sea spray-scented veg.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/raymond-blancs-royal-kitchen-gardens/10a3079"
+      },
+      {
+        "duration": 120,
+        "end": "2024-03-10T12:32:00Z",
+        "legacyId": "NET10SU24-NN12",
+        "start": "2024-03-10T12:30:00Z",
+        "title": "ITV News Weekend Lunch"
+      },
+      {
+        "duration": 60,
+        "end": "2024-03-10T12:33:00Z",
+        "legacyId": "NET10SU24-NW12",
+        "start": "2024-03-10T12:32:00Z",
+        "title": "ITV Weather"
+      },
+      {
+        "duration": 120,
+        "end": "2024-03-10T12:35:00Z",
+        "legacyId": "LON10SU24-WX12",
+        "start": "2024-03-10T12:33:00Z",
+        "title": "ITV Regional Weather"
+      },
+      {
+        "duration": 3300,
+        "end": "2024-03-10T13:30:00Z",
+        "legacyId": "10/5408/0001#001",
+        "start": "2024-03-10T12:35:00Z",
+        "title": "Alan Titchmarsh's Gardening Club",
+        "ccid": "7qxtgr8",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 1,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Alan Titchmarsh and his Gardening Club team share invaluable tips, tricks and insights for seasoned and aspiring gardeners - from houseplants to inner-city gardens & more.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/alan-titchmarshs-gardening-club/10a5408/10a5408a0001",
+        "programmeLink": "/alan-titchmarshs-gardening-club/10a5408"
+      },
+      {
+        "duration": 5400,
+        "end": "2024-03-10T15:00:00Z",
+        "legacyId": "1/6128/0087#002",
+        "start": "2024-03-10T13:30:00Z",
+        "title": "Ant & Dec's Saturday Night Takeaway"
+      },
+      {
+        "duration": 7800,
+        "end": "2024-03-10T17:10:00Z",
+        "legacyId": "2/6556/0001#001",
+        "start": "2024-03-10T15:00:00Z",
+        "title": "Mamma Mia! Here We Go Again"
+      },
+      {
+        "duration": 3300,
+        "end": "2024-03-10T18:05:00Z",
+        "legacyId": "2/1400/0133#001",
+        "start": "2024-03-10T17:10:00Z",
+        "title": "The Chase Celebrity Special",
+        "ccid": "65mt6b8",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 9,
+        "contentType": "EPISODE",
+        "seriesNumber": 12,
+        "description": "Celebrity series of The Chase. Watch them pit their wits against the Chaser, a ruthless quiz genius determined to stop them winning the cash prize.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/the-chase-celebrity-special/2a1400"
+      },
+      {
+        "duration": 480,
+        "end": "2024-03-10T18:13:00Z",
+        "legacyId": "2/4546/0848#001",
+        "start": "2024-03-10T18:05:00Z",
+        "title": "ITV News Weekend Teatime"
+      },
+      {
+        "duration": 120,
+        "end": "2024-03-10T18:15:00Z",
+        "legacyId": "NET10SU24-NW18",
+        "start": "2024-03-10T18:13:00Z",
+        "title": "ITV Weather"
+      },
+      {
+        "duration": 480,
+        "end": "2024-03-10T18:23:00Z",
+        "legacyId": "LON10SU24-RN18",
+        "start": "2024-03-10T18:15:00Z",
+        "title": "ITV News Regional"
+      },
+      {
+        "duration": 120,
+        "end": "2024-03-10T18:25:00Z",
+        "legacyId": "LON10SU24-WX18",
+        "start": "2024-03-10T18:23:00Z",
+        "title": "ITV Regional Weather"
+      },
+      {
+        "duration": 5700,
+        "end": "2024-03-10T20:00:00Z",
+        "legacyId": "2/5040/0077#001",
+        "start": "2024-03-10T18:25:00Z",
+        "title": "Dancing on Ice"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T21:00:00Z",
+        "legacyId": "1/7907/0174#001",
+        "start": "2024-03-10T20:00:00Z",
+        "title": "Who Wants to Be a Millionaire?",
+        "ccid": "wwrjdfk",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 26,
+        "contentType": "EPISODE",
+        "seriesNumber": 34,
+        "description": "Tense gameshow where contestants compete for a top prize of one million pounds. Can they answer fifteen questions correctly with just a handful of lifelines to help them?",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/who-wants-to-be-a-millionaire/33753"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T22:00:00Z",
+        "legacyId": "10/5342/0006#001",
+        "start": "2024-03-10T21:00:00Z",
+        "title": "Celebrity Big Brother"
+      },
+      {
+        "duration": 720,
+        "end": "2024-03-10T22:12:00Z",
+        "legacyId": "NET10SU24-NN22",
+        "start": "2024-03-10T22:00:00Z",
+        "title": "ITV News Weekend Late"
+      },
+      {
+        "duration": 60,
+        "end": "2024-03-10T22:13:00Z",
+        "legacyId": "NET10SU24-NW22",
+        "start": "2024-03-10T22:12:00Z",
+        "title": "ITV Weather"
+      },
+      {
+        "duration": 120,
+        "end": "2024-03-10T22:15:00Z",
+        "legacyId": "LON10SU24-WX22",
+        "start": "2024-03-10T22:13:00Z",
+        "title": "ITV Regional Weather"
+      },
+      {
+        "duration": 15600,
+        "end": "2024-03-11T02:35:00Z",
+        "legacyId": "10/4500/0001#001",
+        "start": "2024-03-10T22:15:00Z",
+        "title": "Oscars Live"
+      },
+      {
+        "duration": 4500,
+        "end": "2024-03-11T03:50:00Z",
+        "legacyId": "10/2272/0093#001",
+        "start": "2024-03-11T02:35:00Z",
+        "title": "English Football League Highlights",
+        "ccid": "qwq0xt7",
+        "contentTypeITV": "avod",
+        "genre": "Sport",
+        "episodeNumber": 41,
+        "contentType": "EPISODE",
+        "seriesNumber": null,
+        "description": "All the highlights, action and talking points from the latest English Football League matches.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/english-football-league-highlights/10a2272/10a2272a0093",
+        "programmeLink": "/english-football-league-highlights/10a2272"
+      },
+      {
+        "duration": 4500,
+        "end": "2024-03-11T05:05:00Z",
+        "legacyId": "10/1889/0873#001",
+        "start": "2024-03-11T03:50:00Z",
+        "title": "Unwind With ITV1"
+      },
+      {
+        "duration": 3300,
+        "end": "2024-03-11T06:00:00Z",
+        "legacyId": "10/4512/0001#002",
+        "start": "2024-03-11T05:05:00Z",
+        "title": "Fletchers' Family Farm"
+      }
+    ],
+    "ITV2": [
+      {
+        "duration": 1500,
+        "end": "2024-03-10T06:25:00Z",
+        "legacyId": "2/7332/0099#001",
+        "start": "2024-03-10T06:00:00Z",
+        "title": "Craig of the Creek",
+        "ccid": "936k1mp",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 22,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Animated comedy following the adventures of Craig and his two friends Kelsey and JP as they explore the wilderness of the creek together.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/craig-of-the-creek/2a7332"
+      },
+      {
+        "duration": 900,
+        "end": "2024-03-10T06:40:00Z",
+        "legacyId": "2/3033/0244#001",
+        "start": "2024-03-10T06:25:00Z",
+        "title": "Teen Titans Go!",
+        "ccid": "kxs4kff",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 36,
+        "contentType": "EPISODE",
+        "seriesNumber": 6,
+        "description": "Animated series based on DC Comics' superhero team. Robin, Cyborg, Starfire, Raven and Beast Boy love saving the world. But when they stop fighting crime, things don't go to plan.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/teen-titans-go/2a3033"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T06:50:00Z",
+        "legacyId": "2/3033/0282#001",
+        "start": "2024-03-10T06:40:00Z",
+        "title": "Teen Titans Go!",
+        "ccid": "rrv88tz",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 19,
+        "contentType": "EPISODE",
+        "seriesNumber": 7,
+        "description": "Animated series based on DC Comics' superhero team. Robin, Cyborg, Starfire, Raven and Beast Boy love saving the world. But when they stop fighting crime, things don't go to plan.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/teen-titans-go/2a3033"
+      },
+      {
+        "duration": 900,
+        "end": "2024-03-10T07:05:00Z",
+        "legacyId": "10/4012/0019#001",
+        "start": "2024-03-10T06:50:00Z",
+        "title": "Looney Tunes Cartoons",
+        "ccid": "sjzjmjt",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 19,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Collection of much-loved Looney Tunes favourite characters - Bugs Bunny, Daffy Duck, Porky Pig - as they get up to no good!",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/looney-tunes-cartoons/10a4012"
+      },
+      {
+        "duration": 900,
+        "end": "2024-03-10T07:20:00Z",
+        "legacyId": "10/4012/0057#001",
+        "start": "2024-03-10T07:05:00Z",
+        "title": "Looney Tunes Cartoons",
+        "ccid": "sjzjx7f",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 6,
+        "contentType": "EPISODE",
+        "seriesNumber": 4,
+        "description": "Collection of much-loved Looney Tunes favourite characters - Bugs Bunny, Daffy Duck, Porky Pig - as they get up to no good!",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/looney-tunes-cartoons/10a4012"
+      },
+      {
+        "duration": 1500,
+        "end": "2024-03-10T07:45:00Z",
+        "legacyId": "2/4672/0028#001",
+        "start": "2024-03-10T07:20:00Z",
+        "title": "Scooby-Doo! Mystery Incorporated",
+        "ccid": "fr667xj",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 2,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "From monsters to bizarre man crabs, Scooby-Doo and the gang try to solve creepy mysteries in the town of Crystal Cove, a place with a reputation for eerie supernatural events.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/scooby-doo-mystery-incorporated/2a4672"
+      },
+      {
+        "duration": 1500,
+        "end": "2024-03-10T08:10:00Z",
+        "legacyId": "2/4501/0046#002",
+        "start": "2024-03-10T07:45:00Z",
+        "title": "Be Cool, Scooby-Doo!",
+        "ccid": "69t3m4k",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 20,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "The Scooby gang are together this summer, but monsters and ghouls get in the way of their adventures. Will they survive?",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/be-cool-scooby-doo/2a4501"
+      },
+      {
+        "duration": 1500,
+        "end": "2024-03-10T08:35:00Z",
+        "legacyId": "2/4671/0037#001",
+        "start": "2024-03-10T08:10:00Z",
+        "title": "What's New Scooby Doo?",
+        "ccid": "gbtstks",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 9,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Whilst trying out sand-building and visiting video games conventions, Scooby-Doo and the Mystery gang are launched into the 21st century, with new mysteries to solve.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/whats-new-scooby-doo/2a4671"
+      },
+      {
+        "duration": 1500,
+        "end": "2024-03-10T09:00:00Z",
+        "legacyId": "10/0597/0051#001",
+        "start": "2024-03-10T08:35:00Z",
+        "title": "Scooby-Doo and Guess Who?",
+        "ccid": "7xlbb64",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 25,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "Throwback to the classic show, with ghost hunts, puzzles and more zany adventures from the madcap team. Joining them this time are a host of celebs in their quest to crack cases.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/scooby-doo-and-guess-who/10a0597"
+      },
+      {
+        "duration": 1500,
+        "end": "2024-03-10T09:25:00Z",
+        "legacyId": "2/1670/0004#001",
+        "start": "2024-03-10T09:00:00Z",
+        "title": "Totally Bonkers Guinness World Records",
+        "ccid": "w5k4np3",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 4,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Matt Edmondson introduces the most entertaining Guinness World Records and the brilliant characters who set them. ",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/totally-bonkers-guinness-world-records/2a1670/2a1670a0004",
+        "programmeLink": "/totally-bonkers-guinness-world-records/2a1670"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T10:25:00Z",
+        "legacyId": "10/0666/0010#002",
+        "start": "2024-03-10T09:25:00Z",
+        "title": "Love Bites"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T11:25:00Z",
+        "legacyId": "2/4985/0019#003",
+        "start": "2024-03-10T10:25:00Z",
+        "title": "Dress To Impress"
+      },
+      {
+        "duration": 5400,
+        "end": "2024-03-10T12:55:00Z",
+        "legacyId": "1/6128/0087#002",
+        "start": "2024-03-10T11:25:00Z",
+        "title": "Ant & Dec's Saturday Night Takeaway"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T13:55:00Z",
+        "legacyId": "2/7615/0040#002",
+        "start": "2024-03-10T12:55:00Z",
+        "title": "Supermarket Sweep",
+        "ccid": "s2h4qh5",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 20,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "A new series of the much-loved game show, presented by Rylan Clark-Neal.",
+        "guidance": "",
+        "episodeAvailableNow": true,
+        "episodeLink": "/supermarket-sweep/2a7615/2a7615a0040",
+        "programmeLink": "/supermarket-sweep/2a7615"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T14:55:00Z",
+        "legacyId": "2/5716/0049#001",
+        "start": "2024-03-10T13:55:00Z",
+        "title": "Celebrity Catchphrase",
+        "ccid": "wlz08qj",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 9,
+        "contentType": "EPISODE",
+        "seriesNumber": 7,
+        "description": "Stephen Mulhern brings the iconic 80s gameshow back in this contemporary remake. Can celebrity contestants identify a familiar catchphrase?",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/celebrity-catchphrase/2a2259/2a5716a0049",
+        "programmeLink": "/celebrity-catchphrase/2a2259"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T15:55:00Z",
+        "legacyId": "10/2097/0001#001",
+        "start": "2024-03-10T14:55:00Z",
+        "title": "Rio",
+        "ccid": "ywfjsqp",
+        "contentTypeITV": "avod",
+        "genre": "Films",
+        "episodeNumber": null,
+        "contentType": "FILM",
+        "seriesNumber": null,
+        "description": null,
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": null
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T16:00:00Z",
+        "legacyId": "1/8987/5185#001",
+        "start": "2024-03-10T15:55:00Z",
+        "title": "Fyi Daily"
+      },
+      {
+        "duration": 2700,
+        "end": "2024-03-10T16:45:00Z",
+        "legacyId": "10/2097/0001#001",
+        "start": "2024-03-10T16:00:00Z",
+        "title": "Rio",
+        "ccid": "ywfjsqp",
+        "contentTypeITV": "avod",
+        "genre": "Films",
+        "episodeNumber": null,
+        "contentType": "FILM",
+        "seriesNumber": null,
+        "description": null,
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": null
+      },
+      {
+        "duration": 3900,
+        "end": "2024-03-10T17:50:00Z",
+        "legacyId": "46494#003",
+        "start": "2024-03-10T16:45:00Z",
+        "title": "Peter Pan"
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T17:55:00Z",
+        "legacyId": "1/8987/5185#001",
+        "start": "2024-03-10T17:50:00Z",
+        "title": "Fyi Daily"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T18:55:00Z",
+        "legacyId": "46494#003",
+        "start": "2024-03-10T17:55:00Z",
+        "title": "Peter Pan"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T19:55:00Z",
+        "legacyId": "2/4755/0001#003",
+        "start": "2024-03-10T18:55:00Z",
+        "title": "Johnny English Reborn"
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T20:00:00Z",
+        "legacyId": "1/8987/5185#001",
+        "start": "2024-03-10T19:55:00Z",
+        "title": "Fyi Daily"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T21:00:00Z",
+        "legacyId": "2/4755/0001#003",
+        "start": "2024-03-10T20:00:00Z",
+        "title": "Johnny English Reborn"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T21:30:00Z",
+        "legacyId": "2/4259/0014#001",
+        "start": "2024-03-10T21:00:00Z",
+        "title": "Family Guy",
+        "ccid": "ph0f6gw",
+        "contentTypeITV": "avod",
+        "genre": "Comedy",
+        "episodeNumber": 7,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "Join the utterly bonkers Griffin family on their wacky escapades in this irreverent sitcom. Watch them strive to cope with everyday life as they lurch from crazy to even crazier.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/family-guy/2a4259"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T22:00:00Z",
+        "legacyId": "2/4259/0015#002",
+        "start": "2024-03-10T21:30:00Z",
+        "title": "Family Guy",
+        "ccid": "n9xgdxd",
+        "contentTypeITV": "avod",
+        "genre": "Comedy",
+        "episodeNumber": 8,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "Join the utterly bonkers Griffin family on their wacky escapades in this irreverent sitcom. Watch them strive to cope with everyday life as they lurch from crazy to even crazier.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/family-guy/2a4259"
+      },
+      {
+        "duration": 3900,
+        "end": "2024-03-10T23:05:00Z",
+        "legacyId": "10/5343/0006#001",
+        "start": "2024-03-10T22:00:00Z",
+        "title": "Celebrity Big Brother: Late & Live"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T23:35:00Z",
+        "legacyId": "2/4259/0007#001",
+        "start": "2024-03-10T23:05:00Z",
+        "title": "Family Guy",
+        "ccid": "z754trf",
+        "contentTypeITV": "avod",
+        "genre": "Comedy",
+        "episodeNumber": 7,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Join the utterly bonkers Griffin family on their wacky escapades in this irreverent sitcom. Watch them strive to cope with everyday life as they lurch from crazy to even crazier.",
+        "guidance": "Contains adult humour.",
+        "episodeAvailableNow": true,
+        "episodeLink": "/family-guy/2a4259/2a4259a0007",
+        "programmeLink": "/family-guy/2a4259"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T00:05:00Z",
+        "legacyId": "2/4263/0003#001",
+        "start": "2024-03-10T23:35:00Z",
+        "title": "American Dad!",
+        "ccid": "h7dfzrt",
+        "contentTypeITV": "avod",
+        "genre": "Comedy",
+        "episodeNumber": 3,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "From the creator of Family Guy comes CIA agent Stan Smith who thinks he can save America - and his family - from every threat. Except things tend to turn out in absurd ways...",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/american-dad/2a4263"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T00:35:00Z",
+        "legacyId": "2/4263/0273#001",
+        "start": "2024-03-11T00:05:00Z",
+        "title": "American Dad!",
+        "ccid": "ty1kx7t",
+        "contentTypeITV": "avod",
+        "genre": "Comedy",
+        "episodeNumber": 26,
+        "contentType": "EPISODE",
+        "seriesNumber": 15,
+        "description": "From the creator of Family Guy comes CIA agent Stan Smith who thinks he can save America - and his family - from every threat. Except things tend to turn out in absurd ways...",
+        "guidance": "Contains adult humour with scenes that some viewers may find offensive.",
+        "episodeAvailableNow": true,
+        "episodeLink": "/american-dad/2a4263/2a4263a0273",
+        "programmeLink": "/american-dad/2a4263"
+      },
+      {
+        "duration": 2400,
+        "end": "2024-03-11T01:15:00Z",
+        "legacyId": "2/5129/0038#001",
+        "start": "2024-03-11T00:35:00Z",
+        "title": "Iain Stirling's CelebAbility",
+        "ccid": "mn60fcl",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 2,
+        "contentType": "EPISODE",
+        "seriesNumber": 6,
+        "description": "Iain Stirling hosts this uproarious celeb vs public comedy game show where five friends take on five famous faces with unusual skills, in order to win cash prizes.",
+        "guidance": "With some strong language and adult humour.",
+        "episodeAvailableNow": true,
+        "episodeLink": "/iain-stirlings-celebability/2a5129/2a5129a0038",
+        "programmeLink": "/iain-stirlings-celebability/2a5129"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-11T02:15:00Z",
+        "legacyId": "2/1670/0009#001",
+        "start": "2024-03-11T01:15:00Z",
+        "title": "Totally Bonkers Guinness World Records",
+        "ccid": "k7pjk41",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 1,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "Matt Edmondson introduces the most entertaining Guinness World Records and the brilliant characters who set them. ",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/totally-bonkers-guinness-world-records/2a1670/2a1670a0009",
+        "programmeLink": "/totally-bonkers-guinness-world-records/2a1670"
+      },
+      {
+        "duration": 2700,
+        "end": "2024-03-11T03:00:00Z",
+        "legacyId": "10/1889/0833#001",
+        "start": "2024-03-11T02:15:00Z",
+        "title": "Unwind With ITV2"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T03:30:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T03:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:00:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T03:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:30:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T04:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:00:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T04:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:30:00Z",
+        "legacyId": "HST/JHNE01/1800",
+        "start": "2024-03-11T05:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T06:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T05:30:00Z",
+        "title": "Teleshopping"
+      }
+    ],
+    "ITVBe": [
+      {
+        "duration": 1800,
+        "end": "2024-03-10T06:30:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-10T06:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T07:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-10T06:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T08:00:00Z",
+        "legacyId": "10/0574/0021#002",
+        "start": "2024-03-10T07:00:00Z",
+        "title": "The Real Housewives of Jersey"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T09:00:00Z",
+        "legacyId": "2/4352/0060#001",
+        "start": "2024-03-10T08:00:00Z",
+        "title": "Buying and Selling",
+        "ccid": "xx07fg6",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 21,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Reality series where property experts Jon and Drew help homeowners take their next step up the ladder. From renovation to buying and selling, the pair have got all bases covered.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/buying-and-selling/2a4352/2a4352a0060",
+        "programmeLink": "/buying-and-selling/2a4352"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T09:10:00Z",
+        "legacyId": "2/7165/0011#001",
+        "start": "2024-03-10T09:00:00Z",
+        "title": "Wildwoods",
+        "ccid": "rns20k7",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 11,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Best friends Cooper the giant sasquatch and Poppy the sugar glider have adventures together in the beautiful wild woods!",
+        "guidance": "",
+        "episodeAvailableNow": true,
+        "episodeLink": "/wildwoods/2a7165/2a7165a0011",
+        "programmeLink": "/wildwoods/2a7165"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T09:20:00Z",
+        "legacyId": "1/9657/0010#003",
+        "start": "2024-03-10T09:10:00Z",
+        "title": "Chloe's Closet"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T09:30:00Z",
+        "legacyId": "2/6125/0005#001",
+        "start": "2024-03-10T09:20:00Z",
+        "title": "Lily's Driftwood Bay",
+        "ccid": "hjc98y0",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 5,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Gentle animation about a little girl called Lily, who dreams up a world of fun and adventure with animal friends. She makes treasure out of everything that she finds on the beach.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/lilys-driftwood-bay/2a6125/2a6125a0005",
+        "programmeLink": "/lilys-driftwood-bay/2a6125"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T09:40:00Z",
+        "legacyId": "1/9014/0048#001",
+        "start": "2024-03-10T09:30:00Z",
+        "title": "The Hive",
+        "ccid": "dppf6bq",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 46,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "This friendly animation for pre-schoolers is based around Bee family, who live in Honeybee Hive. Pappa Bee, Mamma Bee, Buzzbee and Rubee are tiny, stripy and buzz around a lot!",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/the-hive/1a9014/1a9014a0048",
+        "programmeLink": "/the-hive/1a9014"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T09:50:00Z",
+        "legacyId": "1/9014/0027#001",
+        "start": "2024-03-10T09:40:00Z",
+        "title": "The Hive",
+        "ccid": "j8hp1t8",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 25,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "This friendly animation for pre-schoolers is based around Bee family, who live in Honeybee Hive. Pappa Bee, Mamma Bee, Buzzbee and Rubee are tiny, stripy and buzz around a lot!",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/the-hive/1a9014/1a9014a0027",
+        "programmeLink": "/the-hive/1a9014"
+      },
+      {
+        "duration": 900,
+        "end": "2024-03-10T10:05:00Z",
+        "legacyId": "2/6167/0030#001",
+        "start": "2024-03-10T09:50:00Z",
+        "title": "Claude",
+        "ccid": "nvfdkmm",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 30,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Based on the best-selling series of books by Alex T. Smith, Claude follows the adventures of a beret-wearing dog, Claude, and his friend, Sir Bobblysock, in the town of Pawhaven.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/claude/2a6167/2a6167a0030",
+        "programmeLink": "/claude/2a6167"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T10:15:00Z",
+        "legacyId": "10/3221/0016#001",
+        "start": "2024-03-10T10:05:00Z",
+        "title": "Minibods",
+        "ccid": "pnk233b",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 16,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Welcome to the Land of Odd, home to six furry little friends who get caught up in brilliant mayhem, turning everyday situations into unexpected, silly events.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/minibods/10a3221/10a3221a0016",
+        "programmeLink": "/minibods/10a3221"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T10:25:00Z",
+        "legacyId": "10/4810/0010#001",
+        "start": "2024-03-10T10:15:00Z",
+        "title": "Interstellar Ella",
+        "ccid": "7ptfq4m",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 10,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "In the year 3021, on a space station somewhere between Mars and Jupiter in the Milky Way, eight-year-old Ella Ryder sets out with her friends on exciting adventures of discovery.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/interstellar-ella/10a4810/10a4810a0010",
+        "programmeLink": "/interstellar-ella/10a4810"
+      },
+      {
+        "duration": 900,
+        "end": "2024-03-10T10:40:00Z",
+        "legacyId": "1/9579/0008#002",
+        "start": "2024-03-10T10:25:00Z",
+        "title": "Sooty",
+        "ccid": "56df354",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 8,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Fifth incarnation of the slapstick kids puppet show. Follow the mischievous adventures of Sooty, Sweep and Soo - there's a crazy hoover on the loose, sports day, and a magic show!",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/sooty/1a9579/1a9579a0008",
+        "programmeLink": "/sooty/1a9579"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T10:50:00Z",
+        "legacyId": "2/6160/0016#001",
+        "start": "2024-03-10T10:40:00Z",
+        "title": "Pingu in the City",
+        "ccid": "b4x2wbx",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 16,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Pingu and his family move from their small village to a city. The ever-curious penguin tries out many jobs, but his mischievous side often gets the better of him. Naughty naughty!",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/pingu-in-the-city/2a6160/2a6160a0016",
+        "programmeLink": "/pingu-in-the-city/2a6160"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T11:00:00Z",
+        "legacyId": "10/2065/0014#001",
+        "start": "2024-03-10T10:50:00Z",
+        "title": "Bob the Builder",
+        "ccid": "mtxsdhw",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 14,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Animated kids series about a happy builder and his team. There are garages and houses to build, pop-up shops to construct and power failures to fix - can they get to them all?",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/bob-the-builder/10a2065/10a2065a0014",
+        "programmeLink": "/bob-the-builder/10a2065"
+      },
+      {
+        "duration": 900,
+        "end": "2024-03-10T11:15:00Z",
+        "legacyId": "10/2065/0015#001",
+        "start": "2024-03-10T11:00:00Z",
+        "title": "Bob the Builder",
+        "ccid": "s65m6l4",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 15,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Animated kids series about a happy builder and his team. There are garages and houses to build, pop-up shops to construct and power failures to fix - can they get to them all?",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/bob-the-builder/10a2065/10a2065a0015",
+        "programmeLink": "/bob-the-builder/10a2065"
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T11:20:00Z",
+        "legacyId": "10/4085/0039#001",
+        "start": "2024-03-10T11:15:00Z",
+        "title": "Teletubbies Let's Go!",
+        "ccid": "6j12tb1",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 39,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Preschool series based on the iconic 90s TV show. Welcome to the well-known characters of Tinky Winky, Dipsy, Laa-Laa and Po, alongside lots of other sweet new sun babies.",
+        "guidance": "",
+        "episodeAvailableNow": true,
+        "episodeLink": "/teletubbies-lets-go/10a4085/10a4085a0039",
+        "programmeLink": "/teletubbies-lets-go/10a4085"
+      },
+      {
+        "duration": 1200,
+        "end": "2024-03-10T11:40:00Z",
+        "legacyId": "10/3282/0042#001",
+        "start": "2024-03-10T11:20:00Z",
+        "title": "Postman Pat (Classic)",
+        "ccid": "2ds1ybh",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 2,
+        "contentType": "EPISODE",
+        "seriesNumber": 8,
+        "description": "Follow everyone's favourite postie & his cat on his daily rounds in the village of Greendale.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/postman-pat-classic/10a5179/10a3282a0042",
+        "programmeLink": "/postman-pat-classic/10a5179"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T11:50:00Z",
+        "legacyId": "2/6035/0035#001",
+        "start": "2024-03-10T11:40:00Z",
+        "title": "Pip Ahoy!",
+        "ccid": "s4b79dc",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 9,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "Animated show following the adventures of a puppy named Pip and his best friend, a kitten named Alba. They visit island beaches, secret forest trails and many other excitements!",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/pip-ahoy/2a6035/2a6035a0035",
+        "programmeLink": "/pip-ahoy/2a6035"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T12:00:00Z",
+        "legacyId": "10/1304/0010#001",
+        "start": "2024-03-10T11:50:00Z",
+        "title": "The Day Henry Met?",
+        "ccid": "qnk8v57",
+        "contentTypeITV": "avod",
+        "genre": "Children",
+        "episodeNumber": 10,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Everyday Henry meets something new. How exciting - I wonder what Henry's going to meet today?",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/the-day-henry-met/10a1304/10a1304a0010",
+        "programmeLink": "/the-day-henry-met/10a1304"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T12:10:00Z",
+        "legacyId": "2/3807/0005#001",
+        "start": "2024-03-10T12:00:00Z",
+        "title": "Be Beautiful",
+        "ccid": "r4shfjx",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 5,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "The best make-up artists and beauty vloggers dish out their top tips in make-up tutorials. Watch them help celebs including TOWIE's Ferne McCann transform their looks.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/be-beautiful/2a3807/2a3807a0005",
+        "programmeLink": "/be-beautiful/2a3807"
+      },
+      {
+        "duration": 3000,
+        "end": "2024-03-10T13:00:00Z",
+        "legacyId": "1/9824/0298#002",
+        "start": "2024-03-10T12:10:00Z",
+        "title": "The Real Housewives Of Orange County S16"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T14:00:00Z",
+        "legacyId": "1/9824/0299#002",
+        "start": "2024-03-10T13:00:00Z",
+        "title": "The Real Housewives Of Orange County S16"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T15:00:00Z",
+        "legacyId": "1/9824/0300#002",
+        "start": "2024-03-10T14:00:00Z",
+        "title": "The Real Housewives Of Orange County S16"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T16:00:00Z",
+        "legacyId": "1/9824/0301#002",
+        "start": "2024-03-10T15:00:00Z",
+        "title": "The Real Housewives Of Orange County S16"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T17:00:00Z",
+        "legacyId": "1/9824/0302#002",
+        "start": "2024-03-10T16:00:00Z",
+        "title": "The Real Housewives Of Orange County S16"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T18:00:00Z",
+        "legacyId": "10/3202/0019#001",
+        "start": "2024-03-10T17:00:00Z",
+        "title": "Great Chocolate Showdown",
+        "ccid": "lygds9b",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 3,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Indulge in a decadent chocolate dessert competition with a grand prize. 10 home bakers go head-to-head to create cocoa-themed delights in the hopes of winning $50,000.",
+        "guidance": "",
+        "episodeAvailableNow": true,
+        "episodeLink": "/great-chocolate-showdown/10a3202/10a3202a0019",
+        "programmeLink": "/great-chocolate-showdown/10a3202"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T19:00:00Z",
+        "legacyId": "10/3202/0020#001",
+        "start": "2024-03-10T18:00:00Z",
+        "title": "Great Chocolate Showdown",
+        "ccid": "456p532",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 4,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Indulge in a decadent chocolate dessert competition with a grand prize. 10 home bakers go head-to-head to create cocoa-themed delights in the hopes of winning $50,000.",
+        "guidance": "",
+        "episodeAvailableNow": true,
+        "episodeLink": "/great-chocolate-showdown/10a3202/10a3202a0020",
+        "programmeLink": "/great-chocolate-showdown/10a3202"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T19:30:00Z",
+        "legacyId": "2/2238/0044#001",
+        "start": "2024-03-10T19:00:00Z",
+        "title": "Gino's Italian Escape: Gino's Hidden Italy",
+        "ccid": "jf5yhmk",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 3,
+        "contentType": "EPISODE",
+        "seriesNumber": 7,
+        "description": "Chef Gino D'Acampo discovers the secrets of real Italian food as he undertakes a culinary journey around his native Italy.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/ginos-italian-escape-ginos-hidden-italy/2a2238/2a2238a0044",
+        "programmeLink": "/ginos-italian-escape-ginos-hidden-italy/2a2238"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T20:00:00Z",
+        "legacyId": "2/2238/0045#001",
+        "start": "2024-03-10T19:30:00Z",
+        "title": "Gino's Italian Escape: Gino's Hidden Italy",
+        "ccid": "vv6nrjk",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 4,
+        "contentType": "EPISODE",
+        "seriesNumber": 7,
+        "description": "Chef Gino D'Acampo discovers the secrets of real Italian food as he undertakes a culinary journey around his native Italy.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/ginos-italian-escape-ginos-hidden-italy/2a2238/2a2238a0045",
+        "programmeLink": "/ginos-italian-escape-ginos-hidden-italy/2a2238"
+      },
+      {
+        "duration": 4200,
+        "end": "2024-03-10T21:10:00Z",
+        "legacyId": "10/5281/0001#001",
+        "start": "2024-03-10T20:00:00Z",
+        "title": "Mother's Day",
+        "ccid": "gw6dtm9",
+        "contentTypeITV": "avod",
+        "genre": "Films",
+        "episodeNumber": null,
+        "contentType": "FILM",
+        "seriesNumber": null,
+        "description": null,
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": null
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T21:15:00Z",
+        "legacyId": "1/8987/5186#001",
+        "start": "2024-03-10T21:10:00Z",
+        "title": "Fyi Daily"
+      },
+      {
+        "duration": 4200,
+        "end": "2024-03-10T22:25:00Z",
+        "legacyId": "10/5281/0001#001",
+        "start": "2024-03-10T21:15:00Z",
+        "title": "Mother's Day",
+        "ccid": "gw6dtm9",
+        "contentTypeITV": "avod",
+        "genre": "Films",
+        "episodeNumber": null,
+        "contentType": "FILM",
+        "seriesNumber": null,
+        "description": null,
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": null
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T23:25:00Z",
+        "legacyId": "10/1176/0001#001",
+        "start": "2024-03-10T22:25:00Z",
+        "title": "Botched: Salute to Service"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-11T00:25:00Z",
+        "legacyId": "2/3690/0021#001",
+        "start": "2024-03-10T23:25:00Z",
+        "title": "Botched",
+        "ccid": "sjcx0g5",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 11,
+        "contentType": "EPISODE",
+        "seriesNumber": 2,
+        "description": "US reality series exploring plastic surgery gone horribly wrong. Two of California's most respected cosmetic surgeons attempt to reverse the damage of these botched procedures.",
+        "guidance": "Contains nudity from the outset and scenes of surgery.",
+        "episodeAvailableNow": true,
+        "episodeLink": "/botched/2a3690/2a3690a0021",
+        "programmeLink": "/botched/2a3690"
+      },
+      {
+        "duration": 2100,
+        "end": "2024-03-11T01:00:00Z",
+        "legacyId": "10/1889/0704#001",
+        "start": "2024-03-11T00:25:00Z",
+        "title": "Unwind With ITVBe"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T01:30:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T01:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T02:00:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T01:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T02:30:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T02:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T03:00:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T02:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T03:30:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T03:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:00:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T03:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:30:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T04:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T04:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:30:00Z",
+        "legacyId": "HST/NBJI07/1800",
+        "start": "2024-03-11T05:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T06:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T05:30:00Z",
+        "title": "Teleshopping"
+      }
+    ],
+    "ITV3": [
+      {
+        "duration": 1800,
+        "end": "2024-03-10T06:30:00Z",
+        "legacyId": "10/0403/0024#001",
+        "start": "2024-03-10T06:00:00Z",
+        "title": "Bless This House"
+      },
+      {
+        "duration": 8100,
+        "end": "2024-03-10T08:45:00Z",
+        "legacyId": "917124#004",
+        "start": "2024-03-10T06:30:00Z",
+        "title": "Inspector Morse"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T09:45:00Z",
+        "legacyId": "2/4156/0003#002",
+        "start": "2024-03-10T08:45:00Z",
+        "title": "The Durrells"
+      },
+      {
+        "duration": 7800,
+        "end": "2024-03-10T11:55:00Z",
+        "legacyId": "9D/13067#003",
+        "start": "2024-03-10T09:45:00Z",
+        "title": "Agatha Christie's Marple",
+        "ccid": "34njkq5",
+        "contentTypeITV": "avod",
+        "genre": "Drama & Soaps",
+        "episodeNumber": 4,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Classic whodunnit starring Agatha Christie's favourite female sleuth. As her peers fade into their twilight years, Marple keeps on deducing the truth behind murderous crimes. ",
+        "guidance": "",
+        "episodeAvailableNow": true,
+        "episodeLink": "/agatha-christies-marple/L1286/9Da13067",
+        "programmeLink": "/agatha-christies-marple/L1286"
+      },
+      {
+        "duration": 7800,
+        "end": "2024-03-10T14:05:00Z",
+        "legacyId": "9D/13133#002",
+        "start": "2024-03-10T11:55:00Z",
+        "title": "Agatha Christie's Marple"
+      },
+      {
+        "duration": 3900,
+        "end": "2024-03-10T15:10:00Z",
+        "legacyId": "1/8486/0018/B",
+        "start": "2024-03-10T14:05:00Z",
+        "title": "Rosemary & Thyme",
+        "ccid": "srh8wsv",
+        "contentTypeITV": "avod",
+        "genre": "Drama & Soaps",
+        "episodeNumber": 7,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Popular crime drama about the sleuthing & gardening exploits of Rosemary Boxer & Laura Thyme. As part of their gardening consultancy, they tackle murder, mayhem...and horticulture!",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/rosemary-and-thyme/1a8486"
+      },
+      {
+        "duration": 4200,
+        "end": "2024-03-10T16:20:00Z",
+        "legacyId": "1/8486/0023#001",
+        "start": "2024-03-10T15:10:00Z",
+        "title": "Rosemary & Thyme",
+        "ccid": "qb50m3k",
+        "contentTypeITV": "avod",
+        "genre": "Drama & Soaps",
+        "episodeNumber": 8,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Popular crime drama about the sleuthing & gardening exploits of Rosemary Boxer & Laura Thyme. As part of their gardening consultancy, they tackle murder, mayhem...and horticulture!",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/rosemary-and-thyme/1a8486"
+      },
+      {
+        "duration": 6000,
+        "end": "2024-03-10T18:00:00Z",
+        "legacyId": "PC/6138/05#001",
+        "start": "2024-03-10T16:20:00Z",
+        "title": "Rosemary & Thyme"
+      },
+      {
+        "duration": 7200,
+        "end": "2024-03-10T20:00:00Z",
+        "legacyId": "1/7314/0001#005",
+        "start": "2024-03-10T18:00:00Z",
+        "title": "Vera"
+      },
+      {
+        "duration": 7200,
+        "end": "2024-03-10T22:00:00Z",
+        "legacyId": "1/7314/0020#001",
+        "start": "2024-03-10T20:00:00Z",
+        "title": "Vera",
+        "ccid": "r78cbkd",
+        "contentTypeITV": "avod",
+        "genre": "Drama & Soaps",
+        "episodeNumber": 2,
+        "contentType": "EPISODE",
+        "seriesNumber": 5,
+        "description": "Complex crime drama starring Brenda Blethyn as the obsessive crime-cracker DCI Stanhope. Working alongside her trusted colleagues, she tackles each case with unparalleled professionalism.",
+        "guidance": "Crime scene images. Moderate language. ",
+        "episodeAvailableNow": true,
+        "episodeLink": "/vera/1a7314/1a7314a0020",
+        "programmeLink": "/vera/1a7314"
+      },
+      {
+        "duration": 7200,
+        "end": "2024-03-11T00:00:00Z",
+        "legacyId": "1/1685/0001#011",
+        "start": "2024-03-10T22:00:00Z",
+        "title": "Prime Suspect",
+        "ccid": "ww6s5v2",
+        "contentTypeITV": "avod",
+        "genre": "Drama & Soaps",
+        "episodeNumber": 1,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Helen Mirren is on award-winning form in this ITV classic crime drama. DI Jane Tennison, a skilled top-class detective, battles to prove herself in a male-dominated world.",
+        "guidance": "Contains some crimes scenes some viewers may find distressing and some nudity.",
+        "episodeAvailableNow": true,
+        "episodeLink": "/prime-suspect/1a1685/1a1685a0001",
+        "programmeLink": "/prime-suspect/1a1685"
+      },
+      {
+        "duration": 3000,
+        "end": "2024-03-11T00:50:00Z",
+        "legacyId": "1/9089/0019#003",
+        "start": "2024-03-11T00:00:00Z",
+        "title": "DCI Banks"
+      },
+      {
+        "duration": 3000,
+        "end": "2024-03-11T01:40:00Z",
+        "legacyId": "1/9089/0020#003",
+        "start": "2024-03-11T00:50:00Z",
+        "title": "DCI Banks"
+      },
+      {
+        "duration": 1500,
+        "end": "2024-03-11T02:05:00Z",
+        "legacyId": "10/0403/0026#001",
+        "start": "2024-03-11T01:40:00Z",
+        "title": "Bless This House",
+        "ccid": "t0qjhfc",
+        "contentTypeITV": "avod",
+        "genre": "Comedy",
+        "episodeNumber": 2,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Sid James is a salesman who longs for the quiet life. He'd love to simply ogle women, drink bitter and follow his beloved Chelsea FC - but his wife and kids just get in the way.",
+        "guidance": "",
+        "episodeAvailableNow": true,
+        "episodeLink": "/bless-this-house/10a0403/10a0403a0026",
+        "programmeLink": "/bless-this-house/10a0403"
+      },
+      {
+        "duration": 1500,
+        "end": "2024-03-11T02:30:00Z",
+        "legacyId": "10/1889/0832#001",
+        "start": "2024-03-11T02:05:00Z",
+        "title": "Unwind With ITV3"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T03:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T02:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T03:30:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T03:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T03:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:30:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T04:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T04:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:30:00Z",
+        "legacyId": "HST/BXLS16/1800",
+        "start": "2024-03-11T05:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T06:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T05:30:00Z",
+        "title": "Teleshopping"
+      }
+    ],
+    "ITV4": [
+      {
+        "duration": 3300,
+        "end": "2024-03-10T06:55:00Z",
+        "legacyId": "10/4084/0002#002",
+        "start": "2024-03-10T06:00:00Z",
+        "title": "Lost Car Rescue",
+        "ccid": "xgsq2vc",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 2,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Reality series - follow a team of classic car hunters as they scour the Canada's Northern wilderness. They're out to recover rare vehicles hiding in the bush before they disappear.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/lost-car-rescue/10a4084/10a4084a0002",
+        "programmeLink": "/lost-car-rescue/10a4084"
+      },
+      {
+        "duration": 2100,
+        "end": "2024-03-10T07:30:00Z",
+        "legacyId": "2/6359/0015#001",
+        "start": "2024-03-10T06:55:00Z",
+        "title": "The Car Years",
+        "ccid": "6lfpyl5",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 1,
+        "contentType": "EPISODE",
+        "seriesNumber": 3,
+        "description": "Car fanatics Vicki Butler-Henderson and Alex Riley choose their favourite car from a year in motoring history. Can they convince the expert panel of judges which is best?",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/the-car-years/2a6359/2a6359a0015",
+        "programmeLink": "/the-car-years/2a6359"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T08:00:00Z",
+        "legacyId": "10/1325/0061#001",
+        "start": "2024-03-10T07:30:00Z",
+        "title": "Extreme E: Electric Odyssey",
+        "ccid": "dpf6zxk",
+        "contentTypeITV": "avod",
+        "genre": "Sport",
+        "episodeNumber": 1,
+        "contentType": "EPISODE",
+        "seriesNumber": 4,
+        "description": "Plunge into the thrilling world of Extreme E. Get up to speed with everything you need to know about this all-electric off-road racing.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": null
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T08:30:00Z",
+        "legacyId": "10/2005/0124#001",
+        "start": "2024-03-10T08:00:00Z",
+        "title": "Motorsport Mundial",
+        "ccid": "nds8k4m",
+        "contentTypeITV": "avod",
+        "genre": "Sport",
+        "episodeNumber": 11,
+        "contentType": "EPISODE",
+        "seriesNumber": null,
+        "description": "The latest motorsport news and action from around the globe. From Superbikes to Formula 1, Motorsport Mundial has it all.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/motorsport-mundial/10a2005"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-10T09:00:00Z",
+        "legacyId": "7/0070/0218#001",
+        "start": "2024-03-10T08:30:00Z",
+        "title": "Auto Mundial",
+        "ccid": "4mg2k50",
+        "contentTypeITV": "avod",
+        "genre": "Sport",
+        "episodeNumber": 11,
+        "contentType": "EPISODE",
+        "seriesNumber": null,
+        "description": "The latest news and reviews from the world of cars.",
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": "/auto-mundial/7a0070"
+      },
+      {
+        "duration": 5400,
+        "end": "2024-03-10T10:30:00Z",
+        "legacyId": "10/2272/0093#001",
+        "start": "2024-03-10T09:00:00Z",
+        "title": "English Football League Highlights",
+        "ccid": "qwq0xt7",
+        "contentTypeITV": "avod",
+        "genre": "Sport",
+        "episodeNumber": 41,
+        "contentType": "EPISODE",
+        "seriesNumber": null,
+        "description": "All the highlights, action and talking points from the latest English Football League matches.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/english-football-league-highlights/10a2272/10a2272a0093",
+        "programmeLink": "/english-football-league-highlights/10a2272"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-10T10:40:00Z",
+        "legacyId": "2/4374/0004#001",
+        "start": "2024-03-10T10:30:00Z",
+        "title": "Sport Filler Shows"
+      },
+      {
+        "duration": 6000,
+        "end": "2024-03-10T12:20:00Z",
+        "legacyId": "913648/Y",
+        "start": "2024-03-10T10:40:00Z",
+        "title": "Cadfael",
+        "ccid": "0gx4pxw",
+        "contentTypeITV": "avod",
+        "genre": "Drama & Soaps",
+        "episodeNumber": 1,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Sir Derek Jacobi stars as a medieval monk with a knack for solving mysteries. Based on Ellis Peters' best-selling books, follow Cadfael as he attempts to solve dark crimes.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/cadfael/CADFAEL/913648",
+        "programmeLink": "/cadfael/CADFAEL"
+      },
+      {
+        "duration": 8400,
+        "end": "2024-03-10T14:40:00Z",
+        "legacyId": "ITA/00513/001/A#001",
+        "start": "2024-03-10T12:20:00Z",
+        "title": "Minder on the Orient Express"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T15:40:00Z",
+        "legacyId": "1/9663/0001#004",
+        "start": "2024-03-10T14:40:00Z",
+        "title": "The Far Country"
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T15:45:00Z",
+        "legacyId": "1/8987/5185#001",
+        "start": "2024-03-10T15:40:00Z",
+        "title": "Fyi Daily"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T16:45:00Z",
+        "legacyId": "1/9663/0001#004",
+        "start": "2024-03-10T15:45:00Z",
+        "title": "The Far Country (Cont)"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T17:45:00Z",
+        "legacyId": "18321#001",
+        "start": "2024-03-10T16:45:00Z",
+        "title": "Goldfinger"
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T17:50:00Z",
+        "legacyId": "1/8987/5185#001",
+        "start": "2024-03-10T17:45:00Z",
+        "title": "Fyi Daily"
+      },
+      {
+        "duration": 4200,
+        "end": "2024-03-10T19:00:00Z",
+        "legacyId": "18321#001",
+        "start": "2024-03-10T17:50:00Z",
+        "title": "Goldfinger"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T20:00:00Z",
+        "legacyId": "2/6638/0040#001",
+        "start": "2024-03-10T19:00:00Z",
+        "title": "Cycling: Paris - Nice Highlights"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-10T21:00:00Z",
+        "legacyId": "2/1400/0113#001",
+        "start": "2024-03-10T20:00:00Z",
+        "title": "The Chase Celebrity Special",
+        "ccid": "wsbxpjk",
+        "contentTypeITV": "avod",
+        "genre": "Entertainment",
+        "episodeNumber": 1,
+        "contentType": "EPISODE",
+        "seriesNumber": 11,
+        "description": "Celebrity series of The Chase. Watch them pit their wits against the Chaser, a ruthless quiz genius determined to stop them winning the cash prize.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/the-chase-celebrity-special/2a1400/2a1400a0113",
+        "programmeLink": "/the-chase-celebrity-special/2a1400"
+      },
+      {
+        "duration": 3900,
+        "end": "2024-03-10T22:05:00Z",
+        "legacyId": "2/3029/0001#003",
+        "start": "2024-03-10T21:00:00Z",
+        "title": "Skyfall",
+        "ccid": "8hyb83d",
+        "contentTypeITV": "avod",
+        "genre": "Films",
+        "episodeNumber": null,
+        "contentType": "FILM",
+        "seriesNumber": null,
+        "description": null,
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": null
+      },
+      {
+        "duration": 300,
+        "end": "2024-03-10T22:10:00Z",
+        "legacyId": "1/8987/5186#001",
+        "start": "2024-03-10T22:05:00Z",
+        "title": "Fyi Daily"
+      },
+      {
+        "duration": 6300,
+        "end": "2024-03-10T23:55:00Z",
+        "legacyId": "2/3029/0001#003",
+        "start": "2024-03-10T22:10:00Z",
+        "title": "Skyfall",
+        "ccid": "8hyb83d",
+        "contentTypeITV": "avod",
+        "genre": "Films",
+        "episodeNumber": null,
+        "contentType": "FILM",
+        "seriesNumber": null,
+        "description": null,
+        "guidance": null,
+        "episodeAvailableNow": false,
+        "episodeLink": null,
+        "programmeLink": null
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T00:25:00Z",
+        "legacyId": "2/2885/0005#001",
+        "start": "2024-03-10T23:55:00Z",
+        "title": "River Monsters",
+        "ccid": "wzsk3ny",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 4,
+        "contentType": "EPISODE",
+        "seriesNumber": 5,
+        "description": "Extreme angler Jeremy Wade hunts for freshwater fish with a taste for human flesh. Follow him on this rip-roaring ride through the dark side of nature.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/river-monsters/1a7358/2a2885a0005",
+        "programmeLink": "/river-monsters/1a7358"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T00:55:00Z",
+        "legacyId": "2/2885/0006#001",
+        "start": "2024-03-11T00:25:00Z",
+        "title": "River Monsters",
+        "ccid": "wcn8hpq",
+        "contentTypeITV": "avod",
+        "genre": "Factual",
+        "episodeNumber": 5,
+        "contentType": "EPISODE",
+        "seriesNumber": 5,
+        "description": "Extreme angler Jeremy Wade hunts for freshwater fish with a taste for human flesh. Follow him on this rip-roaring ride through the dark side of nature.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/river-monsters/1a7358/2a2885a0006",
+        "programmeLink": "/river-monsters/1a7358"
+      },
+      {
+        "duration": 3600,
+        "end": "2024-03-11T01:55:00Z",
+        "legacyId": "IMM/00143/010#003",
+        "start": "2024-03-11T00:55:00Z",
+        "title": "Minder"
+      },
+      {
+        "duration": 3300,
+        "end": "2024-03-11T02:50:00Z",
+        "legacyId": "9D/10467/Z#001",
+        "start": "2024-03-11T01:55:00Z",
+        "title": "Dempsey & Makepeace",
+        "ccid": "ypxqmhk",
+        "contentTypeITV": "avod",
+        "genre": "Drama & Soaps",
+        "episodeNumber": 3,
+        "contentType": "EPISODE",
+        "seriesNumber": 1,
+        "description": "Action adventure at its finest. Tough American cop Jim Dempsey and uppercrust British policewoman Harriet Makepeace tackle crime on the streets of London.",
+        "guidance": null,
+        "episodeAvailableNow": true,
+        "episodeLink": "/dempsey-and-makepeace/L0282/9Da10467",
+        "programmeLink": "/dempsey-and-makepeace/L0282"
+      },
+      {
+        "duration": 600,
+        "end": "2024-03-11T03:00:00Z",
+        "legacyId": "10/1889/0785#001",
+        "start": "2024-03-11T02:50:00Z",
+        "title": "Unwind With ITV4"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T03:30:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T03:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T03:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T04:30:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T04:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T04:30:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T05:30:00Z",
+        "legacyId": "RVT/OPMX01/1800",
+        "start": "2024-03-11T05:00:00Z",
+        "title": "Teleshopping"
+      },
+      {
+        "duration": 1800,
+        "end": "2024-03-11T06:00:00Z",
+        "legacyId": "RVT/MCMX01/1800",
+        "start": "2024-03-11T05:30:00Z",
+        "title": "Teleshopping"
+      }
+    ]
+  },
+  "subnav": {
+    "items": [
+      {
+        "name": "2024-03-03",
+        "id": "2024-03-03",
+        "label": "SUN 3",
+        "url": "/watch/tv-guide/2024-03-03"
+      },
+      {
+        "name": "2024-03-04",
+        "id": "2024-03-04",
+        "label": "MON 4",
+        "url": "/watch/tv-guide/2024-03-04"
+      },
+      {
+        "name": "2024-03-05",
+        "id": "2024-03-05",
+        "label": "TUE 5",
+        "url": "/watch/tv-guide/2024-03-05"
+      },
+      {
+        "name": "2024-03-06",
+        "id": "2024-03-06",
+        "label": "WED 6",
+        "url": "/watch/tv-guide/2024-03-06"
+      },
+      {
+        "name": "2024-03-07",
+        "id": "2024-03-07",
+        "label": "THU 7",
+        "url": "/watch/tv-guide/2024-03-07"
+      },
+      {
+        "name": "2024-03-08",
+        "id": "2024-03-08",
+        "label": "FRI 8",
+        "url": "/watch/tv-guide/2024-03-08"
+      },
+      {
+        "name": "2024-03-09",
+        "id": "2024-03-09",
+        "label": "YESTERDAY",
+        "url": "/watch/tv-guide/2024-03-09"
+      },
+      {
+        "name": "2024-03-10",
+        "id": "2024-03-10",
+        "label": "TODAY",
+        "url": "/watch/tv-guide/2024-03-10"
+      },
+      {
+        "name": "2024-03-11",
+        "id": "2024-03-11",
+        "label": "TOMORROW",
+        "url": "/watch/tv-guide/2024-03-11"
+      },
+      {
+        "name": "2024-03-12",
+        "id": "2024-03-12",
+        "label": "TUE 12",
+        "url": "/watch/tv-guide/2024-03-12"
+      },
+      {
+        "name": "2024-03-13",
+        "id": "2024-03-13",
+        "label": "WED 13",
+        "url": "/watch/tv-guide/2024-03-13"
+      },
+      {
+        "name": "2024-03-14",
+        "id": "2024-03-14",
+        "label": "THU 14",
+        "url": "/watch/tv-guide/2024-03-14"
+      },
+      {
+        "name": "2024-03-15",
+        "id": "2024-03-15",
+        "label": "FRI 15",
+        "url": "/watch/tv-guide/2024-03-15"
+      },
+      {
+        "name": "2024-03-16",
+        "id": "2024-03-16",
+        "label": "SAT 16",
+        "url": "/watch/tv-guide/2024-03-16"
+      },
+      {
+        "name": "2024-03-17",
+        "id": "2024-03-17",
+        "label": "SUN 17",
+        "url": "/watch/tv-guide/2024-03-17"
+      }
+    ],
+    "activeItem": "2024-03-10",
+    "type": "items",
+    "monitorHashChange": false,
+    "customTracking": [
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-03"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-04"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-05"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-06"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-07"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-08"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-09"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-10"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-11"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-12"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-13"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-14"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-15"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-16"
+      },
+      {
+        "event": "CLICK",
+        "screen_name": "hub.tv-guide.2024-03-10",
+        "screen_type": "tv-guide",
+        "sub_navigation": "2024-03-17"
+      }
+    ]
+  },
+  "FASTSlider": {
+    "header": {
+      "title": "ITVX Live: Choose a channel to match your mood!",
+      "linkHref": "/watch/collections/itvx-live-choose-a-channel-to-match-your-mood/58DOqcyNCNMqcAWNIFvXzJ",
+      "linkText": "View All",
+      "linkAriaLabel": "View All programmes from the ITVX Live: Choose a channel to match your mood! collection",
+      "logo": null
+    },
+    "items": [
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "Oscars 24/7",
+        "channel": "fast13",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Stream Oscar-featured films 24/7",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-oscars/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "The Chase Channel",
+        "channel": "fast3",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Get your quiz fix",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-thechase/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "Comedy 24/7 Channel",
+        "channel": "fast16",
+        "tagNames": [
+          "live"
+        ],
+        "description": "The channel dedicated to big laughs!",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-comedy247/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "Midsomer Murders Channel",
+        "channel": "fast12",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Every murder, every episode, 24/7",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-midsomermurders/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "Reality 24/7",
+        "channel": "fast5",
+        "tagNames": [
+          "live"
+        ],
+        "description": "All your fave reality shows 24/7",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-reality247/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "TOWIE Channel",
+        "channel": "fast15",
+        "tagNames": [
+          "live"
+        ],
+        "description": "It's TOWIE TV!",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-towie/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "LEGO Universe Channel",
+        "channel": "fast4",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Stream the 24/7 live channel!",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-legouniverse/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "ITV Signed",
+        "channel": "fast7",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Stream the best of ITV in BSL",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-signed/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "ITVX Kids Channel",
+        "channel": "fast6",
+        "tagNames": [
+          "live"
+        ],
+        "description": "From Oddbods to Bob the Builder",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-itvxkids/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "Love Island Channel",
+        "channel": "fast20",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Escape to the villa, any time you like",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-loveisland/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "Vera Channel",
+        "channel": "fast2",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Back-to-back episodes",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-vera/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      },
+      {
+        "imagePresets": {},
+        "contentType": "fastchannelspot",
+        "title": "World Of Morse Channel",
+        "channel": "fast1",
+        "tagNames": [
+          "live"
+        ],
+        "description": "Morse, Lewis & Endeavour - every ep",
+        "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/fast-worldofmorse/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}"
+      }
+    ],
+    "key": "editorial_rail_slot_12_itvx_svod",
+    "isRail": true,
+    "tileType": "standard",
+    "id": "MunvLJ2moE9r35f1YtXmQ",
+    "dataTestId": "fast-slider-on-tv-guide"
+  },
+  "error": false
+}


### PR DESCRIPTION
IPTV Manager is an add-on that integrates live channels from supported video add-ons into the PVR add-on 'IPTV simple'. 
This way live channels from various add-ons can be watched as 'normal' TV channel from Kodi's TV section. 

IPTV Merge is another add-on with a functionality similar to IPTV Manager. According to the author it works with any add-on that supports IPTV Manager.

For this to work you must have configured Kodi to use 'IPTV simple' as PVR add-on and have either IPTV Manager or IPTV Merge installed.

Support for IPTV Manager/Merge can be disabled in viwX's settings. 
