### PR TITLE
Fix: Occasional KeyError['guidance'] in episode listings

### DIFF
--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -410,7 +410,7 @@ def parse_episode_title(title_data, brand_fanart=None):
     # Note: episodeTitle may be None
     title = title_data['episodeTitle'] or title_data['heroCtaLabel']
     img_url = title_data['image']
-    plot = '\n\n'.join((title_data['longDescription'], title_data['guidance'] or ''))
+    plot = '\n\n'.join(t for t in (title_data['longDescription'], title_data.get('guidance')) if t)
     if title_data['premium']:
         plot = premium_plot(plot)
 

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -215,6 +215,11 @@ class Generic(unittest.TestCase):
         item = parsex.parse_episode_title(title_obj)
         is_li_compatible_dict(self, item)
 
+        # An Episode lacking field 'guidance'.
+        title_obj = open_json('json/episodes.json')[4]['episode']
+        item = parsex.parse_episode_title(title_obj)
+        is_li_compatible_dict(self, item)
+
     def test_parse_search_result(self):
         # These files contain programmes, episodes, films and specials both and without a specialProgramm field.
         for file in ('search/search_results_mear.json', 'search/search_monday.json'):

--- a/test/test_docs/json/episodes.json
+++ b/test/test_docs/json/episodes.json
@@ -169,7 +169,7 @@
     }
   },
   {
-    "development_description": "{Paid episode with the non-integer series number 'other'.",
+    "development_description": "Paid episode with the non-integer series number 'other'.",
     "episode": {
       "accessibilityTags": [
         "ad",
@@ -221,6 +221,63 @@
       "subtitled": true,
       "tier": [
         "PAID"
+      ],
+      "visuallySigned": false,
+      "regionalisation": false
+    }
+  },
+  {
+    "development_description": "Episode without a field 'guidance'.",
+    "episode": {
+      "accessibilityTags": [
+        "ad",
+        "s"
+      ],
+      "audioDescribed": true,
+      "availabilityFeatures": [
+        "FAIRPLAY",
+        "HD",
+        "HLS",
+        "SINGLE_TRACK"
+      ],
+      "availabilityFrom": "2023-11-01T00:01:00Z",
+      "availabilityUntil": "2025-10-31T23:59:00Z",
+      "broadcastDateTime": null,
+      "categories": [
+        "DRAMA_AND_SOAPS"
+      ],
+      "ccid": "53wt28m",
+      "channel": "ITV",
+      "heroCtaLabel": "Watch Episode",
+      "contentInfo": "2h",
+      "contentOwner": null,
+      "dateTime": "1970-01-01T00:00:00.000Z",
+      "description": "Tensions run high as the family host a lavish Christmas party",
+      "duration": "2h",
+      "encodedEpisodeId": {
+        "letterA": "1a8697a0016",
+        "underscore": "1_8697_0016"
+      },
+      "episode": null,
+      "episodeId": "1/8697/0016",
+      "episodeTitle": "Downton Abbey Christmas Special 2011 (Series 2)",
+      "fullSeriesRange": [],
+      "image": "https://ovp.itv.com/images/special/53wt28m/itv_hub/06_RailPromoLandscape/16x9?distributionPartner=itv_hub\u0026fallback=standard\u0026w={width}\u0026h={height}\u0026q={quality}\u0026blur={blur}\u0026bg={bg}",
+      "linearContent": false,
+      "longDescription": "It's Christmas 1919 and the family host a lavish Christmas party, but tensions are running high, and Bates' arrest has cast a shadow over the festivities.",
+      "longRunning": false,
+      "notFormattedDuration": "PT2H",
+      "partnership": null,
+      "playlistUrl": "https://magni.itv.com/playlist/itvonline/ITV/1_8697_0016.002",
+      "premium": true,
+      "productionId": "1/8697/0016#002",
+      "productionType": "SPECIAL",
+      "productionYear": 2011,
+      "programmeId": "1/8697",
+      "series": "others",
+      "subtitled": true,
+      "tier": [
+        "FREE"
       ],
       "visuallySigned": false,
       "regionalisation": false


### PR DESCRIPTION
Fixes a rather rare error in some episode listings. Usually it's fixed by ITV within a day or so, but I've run into this error already a few times now, so better allow for the absence of data.