### PR TITLE
Added 'Watch from the start' to live hero items.

### DIFF
--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -185,6 +185,7 @@ def root(_):
     for item in itvx.main_page_items():
         callback = callb_map.get(item['type'], play_title)
         li = Listitem.from_dict(callback, **item['show'])
+        li.context.extend(item.get('ctx_mnu', []))
         _my_list_context_mnu(li, item.get('programme_id'))
         yield li
     yield Listitem.from_dict(list_collections, 'Collections')
@@ -538,7 +539,7 @@ def create_mp4_file_item(name, file_url):
 
 
 @Resolver.register
-def play_stream_live(addon, channel, url, title=None, start_time=None, play_from_start=False):
+def play_stream_live(addon, channel, url=None, title=None, start_time=None, play_from_start=False):
     if url is None:
         url = 'https://simulcast.itv.com/playlist/itvonline/' + channel
         logger.info("Created live url from channel name: '%s'", url)

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -9,6 +9,7 @@ fixtures.global_setup()
 
 import json
 
+from datetime import datetime, timezone
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -16,7 +17,7 @@ from codequick import Listitem
 import xbmcgui
 from xbmcgui import ListItem as XbmcListItem
 
-from test.support.testutils import open_json, open_doc, HttpResponse
+from test.support.testutils import open_json, open_doc, HttpResponse, mockeddt
 from test.support import object_checks
 
 from resources.lib import main
@@ -46,15 +47,21 @@ class Paginator(TestCase):
         result = list(pg)
         self.assertListEqual([], result)
 
-@patch('resources.lib.itvx.get_page_data', return_value=open_json('html/index-data.json'))
+@patch('resources.lib.itvx.get_page_data', return_value=open_json('json/index-data.json'))
 class MainMenu(TestCase):
+    @patch('resources.lib.itvx.parsex.datetime', new=mockeddt)
     def test_main_menu(self, _):
+        mockeddt.mocked_now = datetime.now(tz=timezone.utc).replace(hour=21)
         items = list(main.root.test())
         self.assertGreater(len(items), 10)
+        items_with_ctx_menus = 0
         for item in items:
             self.assertIsInstance(item, Listitem)
-        # Check 'My I=itvX' is present
+            if len(item.context) > 0:
+                items_with_ctx_menus += 1
+        # Check 'My ItvX' is present
         self.assertTrue(items[0].label == 'My itvX')
+        self.assertEqual(6, items_with_ctx_menus)
 
 
 class LiveChannels(TestCase):

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -9,10 +9,12 @@ fixtures.global_setup()
 
 import pytz
 import unittest
+from unittest.mock import patch
 
 from datetime import datetime, timezone, timedelta
+from copy import deepcopy
 
-from support.testutils import open_doc, open_json
+from support.testutils import open_doc, open_json, mockeddt
 from support.object_checks import has_keys, is_li_compatible_dict
 from resources.lib import parsex
 from resources.lib import errors
@@ -61,19 +63,47 @@ class Generic(unittest.TestCase):
         self.assertEqual('thetitle', parsex.sort_title('TheTitle'))
 
     def test_parse_hero(self):
-        data = open_json('html/index-data.json')
+        data = open_json('json/index-data.json')
         for item_data in data['heroContent']:
             obj = parsex.parse_hero_content(item_data)
             has_keys(obj, 'type', 'show')
             self.assertTrue(obj['type'] in main.callb_map.keys())
             is_li_compatible_dict(self, obj['show'])
-        # An item of unknown type
-        item = data['heroContent'][0]
+
+        #An item of unknown type
+        item = deepcopy(data['heroContent'][0])
         item['contentType'] = 'some new type'
         self.assertIsNone(parsex.parse_hero_content(item))
+
         # Invalid item
         item = {'contentType': 'special', 'title': False}
         self.assertIsNone(parsex.parse_hero_content(item))
+
+        # Watch From the start context menu on simulcastSpot item
+        item = deepcopy(data['heroContent'][3])
+        self.assertEqual('simulcastspot', item['contentType'])
+        item['startDateTime'] = '20:15'
+        with patch('resources.lib.parsex.datetime', new=mockeddt):
+            # Programme has already started
+            mockeddt.mocked_now = datetime.now(tz=timezone.utc).replace(hour=21)
+            obj = parsex.parse_hero_content(item)
+            self.assertIsInstance(obj['ctx_mnu'], list)
+            self.assertIsInstance(obj['ctx_mnu'][0], tuple)
+            cmd = obj['ctx_mnu'][0][1]
+            self.assertTrue(cmd.startswith("PlayMedia(plugin://plugin.video.viwx/resources/lib/main/play_stream_live/?"))
+            self.assertTrue('start_time=' in cmd)
+            self.assertTrue('play_from_start=True' in cmd)
+
+            # Programme has yet to start - should return a valid item without context menu.
+            mockeddt.mocked_now = datetime.now(tz=timezone.utc).replace(hour=18)
+            obj = parsex.parse_hero_content(item)
+            self.assertListEqual(obj['ctx_mnu'], [])
+
+            # Invalid start time in ITVX data - should return a valid item without context menu.
+            mockeddt.mocked_now = datetime.now(tz=timezone.utc).replace(hour=22)
+            item['startDateTime'] = '2024-3-16T20:15:00:'
+            obj = parsex.parse_hero_content(item)
+            self.assertListEqual(obj['ctx_mnu'], [])
 
     def test_parse_main_page_short_form_slider(self):
         data = open_json('html/index-data.json')

--- a/test/local/test_tests/test_testutils.py
+++ b/test/local/test_tests/test_testutils.py
@@ -1,0 +1,45 @@
+# ----------------------------------------------------------------------------------------------------------------------
+#  Copyright (c) 2024 Dimitri Kroon.
+#  This file is part of plugin.video.viwx.
+#  SPDX-License-Identifier: GPL-2.0-or-later
+#  See LICENSE.txt
+# ----------------------------------------------------------------------------------------------------------------------
+
+import unittest
+import datetime
+
+
+from test.support import testutils
+
+
+class TestMockedDateTime(unittest.TestCase):
+    def test_mocked_datetime_instantiation(self):
+        dt = testutils.mockeddt(2014, 5, 16, 13, 24, 36)
+        self.assertIsInstance(dt, datetime.datetime)
+
+    def test_mocked_dt_now_naive(self):
+        testutils.mockeddt.mocked_now = mocked_now = datetime.datetime(2024, 12, 11, 10, 9 ,8)
+        now = testutils.mockeddt.now()
+        self.assertEqual(mocked_now, now)
+        self.assertIsNone(now.tzinfo)
+
+        testutils.mockeddt.mocked_now = mocked_now = datetime.datetime(2024, 12, 11, 10, 9, 8, tzinfo=datetime.timezone.utc)
+        now = testutils.mockeddt.now()
+        self.assertNotEqual(mocked_now, now)
+        self.assertIsNone(now.tzinfo)
+
+    def test_mocked_dt_now_aware(self):
+        bst = datetime.timezone(datetime.timedelta(hours=1), 'BST')
+        testutils.mockeddt.mocked_now = mocked_now = datetime.datetime(2024, 12, 11, 10, 9 ,8)
+        now = testutils.mockeddt.now(tz=bst)
+        self.assertIs(now.tzinfo, bst)
+        self.assertNotEqual(mocked_now, now)       # One is naive and the other is aware
+        self.assertEqual(mocked_now.strftime('%H:%M'), now.strftime('%H:%M'))
+
+        testutils.mockeddt.mocked_now = mocked_now = datetime.datetime(2024, 12, 11, 10, 9, 8, tzinfo=datetime.timezone.utc)
+        now = testutils.mockeddt.now(tz=bst)
+        self.assertEqual(mocked_now, now)           # both are aware, base dot the same time
+        self.assertEqual('11:09', now.strftime('%H:%M'))
+        self.assertEqual('10:09', mocked_now.strftime('%H:%M'))
+        self.assertIs(now.tzinfo, bst)
+

--- a/test/support/testutils.py
+++ b/test/support/testutils.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------------------------------------------------
-#  Copyright (c) 2022-2023 Dimitri Kroon.
+#  Copyright (c) 2022-2024 Dimitri Kroon.
 #  This file is part of plugin.video.viwx.
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
@@ -9,6 +9,7 @@ import json
 import os.path
 import re
 
+from datetime import datetime
 from requests.models import Response
 
 
@@ -91,3 +92,15 @@ class HttpResponse(Response):
             if status_code is None:
                 self.status_code = 200
                 self.reason = 'OK'
+
+
+class mockeddt(datetime):
+    mocked_now = datetime.now()
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz:
+            return cls.mocked_now.astimezone(tz)
+        else:
+            return cls.mocked_now.replace(tzinfo=None)
+

--- a/test/test_docs/json/index-data.json
+++ b/test/test_docs/json/index-data.json
@@ -81,21 +81,21 @@
         "Series 1"
       ]
     },
- {
-   "contentType": "simulcastspot",
-   "title": "Britain's Got Talent",
-   "description": "Always entertaining, always surprising, plus Ant & Dec! An epic night in",
-   "channel": "ITV",
-   "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/britainsgottalents17/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
-   "genre": "Entertainment",
-   "ctaLabel": "Watch Live",
-   "ariaLabel": "Watch live, Britain's Got Talent",
-   "contentInfo": ["Entertainment"],
-   "strapline": {"text": "Stream it now", "variant": "live-and-fast"},
-   "startDateTime": "19:30",
-   "endDateTime": "21:00",
-   "tagName": "live"
- },
+    {
+       "contentType": "simulcastspot",
+       "title": "Britain's Got Talent",
+       "description": "Always entertaining, always surprising, plus Ant & Dec! An epic night in",
+       "channel": "ITV",
+       "imageTemplate": "https://ovp.itv.com/images/promotional-artpack/britainsgottalents17/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+       "genre": "Entertainment",
+       "ctaLabel": "Watch Live",
+       "ariaLabel": "Watch live, Britain's Got Talent",
+       "contentInfo": ["Entertainment"],
+       "strapline": {"text": "Stream it now", "variant": "live-and-fast"},
+       "startDateTime": "19:30",
+       "endDateTime": "21:00",
+       "tagName": "live"
+    },
     {
       "imagePresets": {},
       "contentType": "fastchannelspot",

--- a/test/web/test_itvx_html.py
+++ b/test/web/test_itvx_html.py
@@ -373,6 +373,9 @@ class MainPage(unittest.TestCase):
                 # Flag if this changes.
                 self.assertFalse(is_iso_utc_time(item['startDateTime']))
                 self.assertFalse(is_iso_utc_time(item['endDateTime']))
+                # Basic check that start and end times are in HH:MM format in British local time
+                self.assertTrue(t.isdecimal for t in item['startDateTime'].split(':'))
+                self.assertTrue(t.isdecimal for t in item['endDateTime'].split(':'))
             #  TODO: Merge check with similar items from shortFormatSliders and collections
             # elif content_type == 'fastchannelspot':
             #     check_collection_item_type_fastchannelspot(self, item, parent_name='hero-item')


### PR DESCRIPTION
Hero items (those in orange on the main menu) of type simulcast now have a context menu item 'Watch from the start', just like the live channels.