### PR TITLE
Add a 'View all episodes' context menu on items in 'Continue Watching'.

### DIFF
--- a/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
@@ -243,7 +243,7 @@ msgid ""
 msgstr ""
 
 msgctxt "#30803"
-msgid ""
+msgid "View all episodes"
 msgstr ""
 
 msgctxt "#30804"

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -158,6 +158,7 @@ class Paginator:
         for show in shows_list:
             try:
                 li = Listitem.from_dict(callb_map[show['type']], **show['show'])
+                li.context.extend(show.get('ctx_mnu', []))
                 # Create 'My List' add/remove context menu entries here, so as to be able to update these
                 # entries after adding/removing an item, even when the underlying data is cached.
                 _my_list_context_mnu(li, show.get('programme_id'))

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -324,6 +324,26 @@ class Generic(unittest.TestCase):
         item = parsex.parse_last_watched_item(data, utc_now)
         self.assertTrue('0 hours available' in item['show']['info']['plot'])
 
+    def test_last_watched_context_menu(self):
+        data = open_json('usercontent/last_watched_all.json')
+        utc_now = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+
+        episode_item = data[0]
+        self.assertEqual('FILM', episode_item['contentType'])
+        show = parsex.parse_last_watched_item(episode_item, utc_now)
+        self.assertFalse('ctx_mnu' in show.keys())
+
+        episode_item['contentType'] = 'SPECIAL'
+        show = parsex.parse_last_watched_item(episode_item, utc_now)
+        self.assertFalse('ctx_mnu' in show.keys())
+        
+        episode_item['contentType'] = 'EPISODE'
+        show = parsex.parse_last_watched_item(episode_item, utc_now)
+        self.assertIsInstance(show['ctx_mnu'], list)
+        for item in show['ctx_mnu']:
+            self.assertIsInstance(item, tuple)
+
+
     def test_parse_schedule(self):
         data = open_json('json/schedule_data.json')['tvGuideData']
 


### PR DESCRIPTION
Items in 'My ITVX' -> 'Continue Watching' that are episodes of programmes with multiple episodes now have a context menu item to go to the programme's page with all the series and episodes.