### PR TITLE
Properly handle a continue-watching list without items.

### DIFF
--- a/plugin.video.viwx/resources/lib/fetch.py
+++ b/plugin.video.viwx/resources/lib/fetch.py
@@ -269,7 +269,7 @@ def web_request(method, url, headers=None, data=None, **kwargs):
         if 400 <= e.response.status_code < 500:
             # noinspection PyBroadException
             try:
-                resp_data = resp.json()
+                resp_data = json.loads(resp.content.decode('utf8'))
             except:
                 # Intentional broad exception as requests can raise various types of errors
                 # depending on python, etc.
@@ -303,13 +303,13 @@ def post_json(url, data, headers=None, **kwargs):
         dflt_headers.update(headers)
     resp = web_request('POST', url, dflt_headers, data, **kwargs)
     try:
-        return resp.json()
+        return json.loads(resp.content.decode('utf8'))
     except json.JSONDecodeError:
         raise FetchError(Script.localize(30920))
 
 
 def get_json(url, headers=None, **kwargs):
-    """Make a GET reguest and expect JSON data back."""
+    """Make a GET request and expect JSON data back."""
     dflt_headers = {'Accept': 'application/json'}
     if headers:
         dflt_headers.update(headers)
@@ -317,7 +317,7 @@ def get_json(url, headers=None, **kwargs):
     if resp.status_code == 204:     # No Content
         return None
     try:
-        return resp.json()
+        return json.loads(resp.content.decode('utf8'))
     except json.JSONDecodeError:
         raise FetchError(Script.localize(30920))
 
@@ -338,7 +338,7 @@ def delete_json(url, data, headers=None, **kwargs):
     if resp.status_code == 204:     # No Content
         return None
     try:
-        return resp.json()
+        return json.loads(resp.content.decode('utf8'))
     except json.JSONDecodeError:
         raise FetchError(Script.localize(30920))
 

--- a/plugin.video.viwx/resources/lib/fetch.py
+++ b/plugin.video.viwx/resources/lib/fetch.py
@@ -305,7 +305,7 @@ def post_json(url, data, headers=None, **kwargs):
     try:
         return json.loads(resp.content.decode('utf8'))
     except json.JSONDecodeError:
-        raise FetchError(Script.localize(30920))
+        raise ParseError(Script.localize(30920))
 
 
 def get_json(url, headers=None, **kwargs):
@@ -319,7 +319,7 @@ def get_json(url, headers=None, **kwargs):
     try:
         return json.loads(resp.content.decode('utf8'))
     except json.JSONDecodeError:
-        raise FetchError(Script.localize(30920))
+        raise ParseError(Script.localize(30920))
 
 
 def put_json(url, data, headers=None, **kwargs):
@@ -340,7 +340,7 @@ def delete_json(url, data, headers=None, **kwargs):
     try:
         return json.loads(resp.content.decode('utf8'))
     except json.JSONDecodeError:
-        raise FetchError(Script.localize(30920))
+        raise ParseError(Script.localize(30920))
 
 
 def get_document(url, headers=None, **kwargs):

--- a/test/web/test_itvx.py
+++ b/test/web/test_itvx.py
@@ -101,6 +101,10 @@ class TestItvX(unittest.TestCase):
         items = itvx.my_list(uid)
         self.assertGreater(len(items), 1)
 
+    def test_get_last_watched(self):
+        items = itvx.get_last_watched()
+        pass
+
     def test_because_you_watched(self):
         uid = itv_account.itv_session().user_id
         byw_list = itvx.because_you_watched(uid)


### PR DESCRIPTION

Fixes the issue that users could be presented with an error messages when the continue-watched list was empty.