### PR TITLE
Fix: newsclips fail to play with KeyError 'Base'

### DIFF
--- a/plugin.video.viwx/resources/lib/itv.py
+++ b/plugin.video.viwx/resources/lib/itv.py
@@ -152,12 +152,13 @@ def get_catchup_urls(episode_url):
     """
     playlist = _request_stream_data(episode_url, 'catchup')['Playlist']
     stream_data = playlist['Video']
-    url_base = stream_data['Base']
+    url_base = stream_data.get('Base', '')
     video_locations = stream_data['MediaFiles'][0]
     dash_url = url_base + video_locations['Href']
     key_service = video_locations.get('KeyServiceUrl')
     try:
-        # Usually stream_data['Subtitles'] is just None when subtitles are not available.
+        # Usually stream_data['Subtitles'] is just None when subtitles are not available,
+        # but on shortform items it's completely absent.
         subtitles = stream_data['Subtitles'][0]['Href']
     except (TypeError, KeyError, IndexError):
         subtitles = None

--- a/test/local/test_itv.py
+++ b/test/local/test_itv.py
@@ -68,6 +68,24 @@ class RequestStreamData(TestCase):
         self.assertEqual(1, cm.exception.code)
 
 
+class GetCatchupUrls(TestCase):
+    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    def test_catchup_urls(self, _):
+        mpd, key, subs, video_type, prod_id = itv.get_catchup_urls('itv1/url')
+        self.assertTrue(is_url(mpd))
+        self.assertTrue(is_url(key))
+        self.assertTrue(is_url(subs))
+        self.assertEqual(video_type, 'CATCHUP')
+
+    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_news_short.json'))
+    def test_shorform_urls(self, _):
+        mpd, key, subs, video_type, prod_id = itv.get_catchup_urls('itv1/url')
+        self.assertTrue(is_url(mpd))
+        self.assertIsNone(key)
+        self.assertIsNone(subs)
+        self.assertEqual(video_type, 'SHORT')
+
+
 class GetLiveUrls(TestCase):
     @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
     def test_get_dar_urls(self, _):

--- a/test/support/object_checks.py
+++ b/test/support/object_checks.py
@@ -268,16 +268,16 @@ def check_news_collection_stream_info(playlist):
     assert playlist['VideoType'] == 'SHORT'
 
     video_inf = playlist['Video']
-    has_keys(video_inf, 'Duration', 'Base', 'MediaFiles', obj_name="Playlist['Video']")
+    has_keys(video_inf, 'Duration', 'MediaFiles', obj_name="Playlist['Video']")
     # If these are present it is a 'normal' catchup item
-    misses_keys(video_inf, 'Timecodes', 'Subtitles', 'Token', obj_name="Playlist['Video']")
+    misses_keys(video_inf, 'Timecodes', 'Subtitles', 'Token', 'Base', obj_name="Playlist['Video']")
 
     assert isinstance(video_inf['Duration'], str)
 
     strm_inf = video_inf['MediaFiles']
     assert isinstance(strm_inf, list), 'MediaFiles is not a list but {}'.format(type(strm_inf))
     assert len(strm_inf) == 1
-    assert is_url(video_inf['Base'] + strm_inf[0]['Href'], '.mp4')
+    assert is_url(strm_inf[0]['Href'], '.mp4')
 
 
 def check_short_form_slider(testcase, slider, name=''):

--- a/test/test_docs/playlists/pl_news_short.json
+++ b/test/test_docs/playlists/pl_news_short.json
@@ -1,16 +1,33 @@
 {
   "Playlist": {
     "VideoType": "SHORT",
-    "ProductionId": "294f5r9",
+    "ProductionId": "b0qf9t1",
     "Video": {
-      "Duration": "00:00:32:920",
-      "Base": "https://playback.brightcovecdn.com",
+      "Duration": "00:02:00:970",
       "MediaFiles": [
         {
-          "Href": "/playback/v1/accounts/2821697655001/videos/6319711095112/high.mp4?bcov_auth=ewoJInR5cGUiOiAiSldUIiwKCSJhbGciOiAiUlMyNTYiCn0.ewoJImFjY2lkIjogIjI4MjE2OTc2NTUwMDEiCn0.XU9GEvV2NRG__OVbLn9kSt-MX5XHD6MCofzeuD2B89IQOfNYDfPPYk0ZZrQT5Lfj_PNIQh-1UsSGRjpeFu_3IJRtAf5HabobscEcBiAluTw2Vjr5WRTaNeI572h-o2zQosoQ4aNS67hl0LDGWQfAqgjf1H4EPCrQc-GvlGvoXxgpnnPHQfwLIACoN5TYOREKq26sa4wPEu1v-vWGgQBqssk9IUX2bY7ovfzY9gtec4o7pAXosZvMEiPWx3PX7pOb4s13Q6zUReHnCwofnnFewCX2QzgAAUMSqkd73iVA0VWg7Atus6Iag40mJWVoVAOgP_EXFOS76c7GJTb-rOELZw"
+          "Href": "https://playback.brightcovecdn.com/playback/v1/accounts/2821697655001/videos/6364155086112/high.mp4?bcov_auth=ewoJInR5cGUiOiAiSldUIiwKCSJhbGciOiAiUlMyNTYiCn0.ewoJImFjY2lkIjogIjI4MjE2OTc2NTUwMDEiCn0.XU9GEvV2NRG__OVbLn9kSt-MX5XHD6MCofzeuD2B89IQOfNYDfPPYk0ZZrQT5Lfj_PNIQh-1UsSGRjpeFu_3IJRtAf5HabobscEcBiAluTw2Vjr5WRTaNeI572h-o2zQosoQ4aNS67hl0LDGWQfAqgjf1H4EPCrQc-GvlGvoXxgpnnPHQfwLIACoN5TYOREKq26sa4wPEu1v-vWGgQBqssk9IUX2bY7ovfzY9gtec4o7pAXosZvMEiPWx3PX7pOb4s13Q6zUReHnCwofnnFewCX2QzgAAUMSqkd73iVA0VWg7Atus6Iag40mJWVoVAOgP_EXFOS76c7GJTb-rOELZw"
         }
       ]
     },
-    "ContentBreaks": []
+    "ContentBreaks": [
+      {
+        "TimeCode": "00:00:00:000",
+        "Actions": [
+          {
+            "Type": "ident",
+            "Href": "https://tom.itv.com/itv/tserver/tserver/random=8972392461/area=itvplayer.video/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser.x/us=ano/os=linux/pm=free/chanbrand=itv1/site=itv/source=clip/epid=itv.b0qf9t1/progid=dfltprgid,itv.2_4409/epname=the.top.stories.from.itv.news.-.as.kamala.harris.and.donald.trump.make.final.attempts.to.win.voters/size=videoident/adpos=iden1/breaknum=0/viewid=0.29bc1421-f3ed-4950-8573-48af96e44911/generic=29bc1421-f3ed-4950-8573-48af96e44911/epid=itv.b0qf9t1/plist=i1.s0.pm0.pr2.m0.po0/plfcid=304841/linked_fcid=304841/platform=desktop/temphint=/appbundle=itv.dotcom/default=defaultvideo/excludep=65,67,68,70,71,72,74,76,77,141,143"
+          },
+          {
+            "Type": "advert",
+            "Href": "https://tom.itv.com/itv/tserver/tserver/random=8972392461/area=itvplayer.video/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser.x/us=ano/os=linux/pm=free/chanbrand=itv1/site=itv/source=clip/epid=itv.b0qf9t1/progid=dfltprgid,itv.2_4409/epname=the.top.stories.from.itv.news.-.as.kamala.harris.and.donald.trump.make.final.attempts.to.win.voters/size=video/adpos=1/breaknum=0/viewid=0.29bc1421-f3ed-4950-8573-48af96e44911/generic=29bc1421-f3ed-4950-8573-48af96e44911/epid=itv.b0qf9t1/plist=i1.s0.pm0.pr2.m0.po0/plfcid=304841/linked_fcid=304841/platform=desktop/temphint=/appbundle=itv.dotcom/default=defaultvideo/excludep=65,67,68,70,71,72,74,76,77,141,143"
+          },
+          {
+            "Type": "advert",
+            "Href": "https://tom.itv.com/itv/tserver/tserver/random=8972392461/area=itvplayer.video/hdevid=x/hmod=105/hman=firefox/osver=x86_64/dm=92a3bfde-bfe1-40ea-ad43-09b8b522b7cb/pv=browser.x/us=ano/os=linux/pm=free/chanbrand=itv1/site=itv/source=clip/epid=itv.b0qf9t1/progid=dfltprgid,itv.2_4409/epname=the.top.stories.from.itv.news.-.as.kamala.harris.and.donald.trump.make.final.attempts.to.win.voters/size=video/adpos=last/breaknum=0/viewid=0.29bc1421-f3ed-4950-8573-48af96e44911/generic=29bc1421-f3ed-4950-8573-48af96e44911/epid=itv.b0qf9t1/plist=i1.s0.pm0.pr2.m0.po0/plfcid=304841/linked_fcid=304841/platform=desktop/temphint=/appbundle=itv.dotcom/default=defaultvideo/excludep=65,67,68,70,71,72,74,76,77,141,143"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/test/web/test_itvx_api.py
+++ b/test/web/test_itvx_api.py
@@ -733,6 +733,7 @@ class Playlists(unittest.TestCase):
                 url = '/'.join(('https://www.itv.com/watch/news', item['titleSlug'], item['episodeId']))
             playlist_url = itvx.get_playlist_url_from_episode_page(url)
             strm_data = self.get_playlist_catchup(playlist_url)
+            # testutils.save_json(strm_data, 'playlists/pl_news_short.json')
             if is_short:
                 object_checks.check_news_collection_stream_info(strm_data['Playlist'])
             else:


### PR DESCRIPTION

The video links in a shortform's playlist is now a full url and field 'Base' is no longer present in the playlist.