### PR TITLE
Support hero items of type 'episode'.

### DIFF
--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -1,6 +1,6 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
-#  Copyright (c) 2022-2024 Dimitri Kroon.
+#  Copyright (c) 2022-2025 Dimitri Kroon.
 #  This file is part of plugin.video.viwx.
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
@@ -413,10 +413,12 @@ def get_playlist_url_from_episode_page(page_url, prefer_bsl=False):
     data = get_page_data(page_url)
 
     try:
-        episode = data['seriesList'][0]['titles'][0]
-    except KeyError:
-        # news item
+        # news, specials and normal episodes (The latter only occurs when not
+        # selected from a series folder, e.g. as hero item)
         episode = data['episode']
+    except KeyError:
+        # Some pages, like films, do not have a field 'episode', but do have a series list with one item.
+        episode = data['seriesList'][0]['titles'][0]
 
     if prefer_bsl:
         return episode.get('bslPlaylistUrl') or episode['playlistUrl']

--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -156,14 +156,18 @@ def parse_hero_content(hero_data):
             if series_idx:
                 context_mnu.append(ctx_mnu_all_episodes(hero_data['encodedProgrammeId']['letterA']))
 
-        elif item_type in ('special', 'film'):
+        elif item_type in ('special', 'film', 'episode'):
             item['info'].update(plot=''.join(('[B]Watch ',
                                               'FILM' if item_type == 'film' else 'NOW',
                                               '[/B]\n',
                                               hero_data.get('description'))),
                                 duration=utils.duration_2_seconds(hero_data.get('duration')))
-            item['params'] = {'url': build_url(title, hero_data['encodedProgrammeId']['letterA']),
+            item['params'] = {'url': build_url(title,
+                                               hero_data['encodedProgrammeId']['letterA'],
+                                               hero_data.get('encodedEpisodeId', {}).get('letterA')),
                               'name': title}
+            if item_type == 'episode':
+                context_mnu.append(ctx_mnu_all_episodes(hero_data['encodedProgrammeId']['letterA']))
 
         else:
             logger.warning("Hero item %s is of unknown type: %s", hero_data['title'], item_type)

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -62,7 +62,7 @@ class MainMenu(TestCase):
                 items_with_ctx_menus += 1
         # Check 'My ItvX' is present
         self.assertTrue(items[0].label == 'My itvX')
-        self.assertEqual(5, items_with_ctx_menus)
+        self.assertEqual(6, items_with_ctx_menus)
 
 
 class LiveChannels(TestCase):

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -88,6 +88,14 @@ class Generic(unittest.TestCase):
         self.assertEqual(1, len(obj['ctx_mnu']))
         self.assertTrue('list_productions' in obj['ctx_mnu'][0][1])
 
+        # An episode item's context menu 'view all episodes'.
+        item = deepcopy(data['heroContent'][8])
+        self.assertEqual('episode', item['contentType'])
+        obj = parsex.parse_hero_content(item)
+        self.assertIsInstance(obj['ctx_mnu'], list)
+        self.assertEqual(1, len(obj['ctx_mnu']))
+        self.assertTrue('list_productions' in obj['ctx_mnu'][0][1])
+
         # An item of unknown type
         item = deepcopy(data['heroContent'][0])
         item['contentType'] = 'some new type'

--- a/test/test_docs/json/index-data.json
+++ b/test/test_docs/json/index-data.json
@@ -29,26 +29,58 @@
     },
     {
       "ariaLabel": "Watch series 14 of Vera",
-      "attribution": {"contentOwner": null, "partnership": null},
+      "attribution": {
+        "contentOwner": null,
+        "partnership": null
+      },
       "brandImageTemplate": "https://ovp.itv.com/images/programme/mz0gq64/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
       "ccid": "175qdnj",
-      "contentInfo": ["Drama", "Crime & Thriller", "Series 14"],
+      "contentInfo": [
+        "Drama",
+        "Crime & Thriller",
+        "Series 14"
+      ],
       "contentOwner": null,
       "contentType": "series",
       "ctaLabel": "Watch Now",
       "description": "The obsessive crime-cracker is back! Don't miss the gripping final series. As she faces a fresh set of baffling cases, will her dogged pursuit of justice lead her to the truth?",
-      "encodedEpisodeId": {"letterA": "1a7314a0061", "underscore": "1_7314_0061"},
-      "encodedProgrammeId": {"letterA": "1a7314", "underscore": "1_7314"},
-      "genre": ["Drama"],
-      "genres": [{"id": "DRAMA_AND_SOAPS", "name": "Drama"}],
+      "encodedEpisodeId": {
+        "letterA": "1a7314a0061",
+        "underscore": "1_7314_0061"
+      },
+      "encodedProgrammeId": {
+        "letterA": "1a7314",
+        "underscore": "1_7314"
+      },
+      "genre": [
+        "Drama"
+      ],
+      "genres": [
+        {
+          "id": "DRAMA_AND_SOAPS",
+          "name": "Drama"
+        }
+      ],
       "imageTemplate": "https://ovp.itv.com/images/series/175qdnj/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
       "isPaid": false,
       "numberOfEpisodes": 4,
       "partnership": null,
       "programmeId": "1/7314",
       "series": 14,
-      "strapline": {"text": "New series", "variant": "default"},
-      "subgenres": [{"id": "CRIME_AND_THRILLER", "name": "Crime & Thriller"}, {"id": "CONTEMPORARY_BRITISH", "name": "Contemporary"}],
+      "strapline": {
+        "text": "New series",
+        "variant": "default"
+      },
+      "subgenres": [
+        {
+          "id": "CRIME_AND_THRILLER",
+          "name": "Crime & Thriller"
+        },
+        {
+          "id": "CONTEMPORARY_BRITISH",
+          "name": "Contemporary"
+        }
+      ],
       "title": "Vera"
     },
     {
@@ -165,6 +197,53 @@
       ],
       "ctaLabel": "Watch Now",
       "ariaLabel": "Watch an episode of The Beast Must Die"
+    },
+    {
+      "contentType": "episode",
+      "ariaLabel": "Watch Now",
+      "attribution": {
+        "contentOwner": null,
+        "partnership": null
+      },
+      "brandImageTemplate": "https://ovp.itv.com/images/programme/71xn0cw/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "contentInfo": [
+        "Ent & Reality",
+        "Celebrity"
+      ],
+      "contentOwner": null,
+      "ctaLabel": "Series 6, Episode 1",
+      "description": "The Masked Singer is back with more epic outfits & jaw-dropping reveals! And a brand-new detective, Maya Jama, joins the celebrity panel.",
+      "encodedEpisodeId": {
+        "letterA": "2a6976a0065",
+        "underscore": "2_6976_0065"
+      },
+      "encodedProgrammeId": {
+        "letterA": "2a6976",
+        "underscore": "2_6976"
+      },
+      "episode": 1,
+      "genres": [
+        {
+          "id": "ENTERTAINMENT",
+          "name": "Entertainment & Reality"
+        }
+      ],
+      "imageTemplate": "https://ovp.itv.com/images/episode/g4zhx4v/itv_hub/{class}/{aspect_ratio}?distributionPartner={distributionPartner}&fallback={fallback}&treatment={treatment}&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+      "isPaid": false,
+      "partnership": null,
+      "programmeId": "2/6976",
+      "series": 6,
+      "subgenres": [
+        {
+          "id": "CELEBRITY",
+          "name": "Celebrity"
+        },
+        {
+          "id": "MUSIC_PROGRAMMES",
+          "name": "Music Programmes"
+        }
+      ],
+      "title": "The Masked Singer"
     }
   ],
   "editorialSliders": {

--- a/test/web/test_itvx_html.py
+++ b/test/web/test_itvx_html.py
@@ -1,6 +1,6 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
-#  Copyright (c) 2022-2024 Dimitri Kroon.
+#  Copyright (c) 2022-2025 Dimitri Kroon.
 #  This file is part of plugin.video.viwx.
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt
@@ -216,7 +216,8 @@ def check_title(self, title, parent_name):
         self.assertGreater(title['productionYear'], 1900)
         self.assertTrue('episode' not in title)
         self.assertIsNone(title['series'])
-        self.assertEqual(utils.strptime(title['dateTime'], '%Y-%m-%dT%H:%M:%S.%fZ'), datetime(1970, 1, 1))
+        # As of 22-12-2023 some films do have an actual dateTime
+        # self.assertEqual(utils.strptime(title['dateTime'], '%Y-%m-%dT%H:%M:%S.%fZ'), datetime(1970, 1, 1))
 
 
 def check_episode(self, episode, parent_name):
@@ -376,14 +377,15 @@ class MainPage(unittest.TestCase):
         for item in page_props['heroContent']:
             content_type = item['contentType']
             self.assertTrue(content_type in
-                            ('simulcastspot', 'fastchannelspot', 'series', 'film', 'special', 'brand',
+                            ('simulcastspot', 'fastchannelspot', 'series', 'film', 'special', 'episode', 'brand',
                              'collection', 'page', 'upsellspot'))
             if content_type == 'upsellspot':
                 continue
+            obj_name = 'Hero-items.' +  item['title']
             if content_type == 'simulcastspot':
-                check_item_type_simulcastspot(self, item, parent_name='hero-item')
+                check_item_type_simulcastspot(self, item, parent_name='hero-items')
                 # Flag if key normally only present in collections become available in hero items as well
-                misses_keys(item, 'contentinfo', 'progress', obj_name='hero-item.'+ item['title'])
+                misses_keys(item, 'contentinfo', 'progress', obj_name=obj_name)
                 # Start and end times in Simulcastspots in hero are normally not in iso format.
                 # Flag if this changes.
                 self.assertFalse(is_iso_utc_time(item['startDateTime']))
@@ -402,29 +404,32 @@ class MainPage(unittest.TestCase):
                 check_item_type_page(self, item, 'mainpage.hero')
             else:
                 has_keys(item, 'contentType', 'title', 'imageTemplate', 'description', 'ctaLabel', 'ariaLabel',
-                         'contentInfo', obj_name=item['title'])
+                         'contentInfo', obj_name=obj_name)
                 self.assertIsInstance(item['contentInfo'], list)
 
                 if item['contentType']in ('simulcastspot', 'fastchannelspot'):
-                    has_keys(item, 'channel', obj_name=item['title'])
+                    has_keys(item, 'channel', obj_name=obj_name)
                 else:
-                    has_keys(item, 'genres', 'encodedProgrammeId', 'programmeId', obj_name=item['title'])
+                    has_keys(item, 'genres', 'encodedProgrammeId', 'programmeId', obj_name=obj_name)
                     self.assertTrue(is_encoded_programme_id(item['encodedProgrammeId']))
                     check_genres(self, item['genres'])
 
                 if item['contentType'] == 'special':
                     # Field 'dateTime' not always present in special title
-                    has_keys(item, 'encodedEpisodeId', 'duration', obj_name=item['title'])
-                    is_encoded_episode_id()
+                    has_keys(item, 'encodedEpisodeId', 'duration', obj_name=obj_name)
                     self.assertTrue(is_encoded_episode_id(item['encodedEpisodeId']))
 
+                if item['contentType'] == 'episode':
+                    self.assertTrue(is_encoded_episode_id(item['encodedEpisodeId']))
+                    misses_keys(item, 'duration', obj_name=obj_name)
+
                 if item['contentType'] == 'series':
-                    has_keys(item, 'encodedEpisodeId', 'brandImageTemplate', 'series', obj_name=item['title'])
+                    has_keys(item, 'encodedEpisodeId', 'brandImageTemplate', 'series', obj_name=obj_name)
                     self.assertTrue(is_encoded_episode_id(item['encodedEpisodeId']))
 
                 if item['contentType'] == 'film':
                     # Fields not always present:  'dateTime'
-                    has_keys(item, 'productionYear', 'duration', obj_name=item['title'])
+                    has_keys(item, 'productionYear', 'duration', obj_name=obj_name)
 
                 if item['contentType'] == 'brand':
                     # Just to check over time if this is always true
@@ -669,6 +674,9 @@ class WatchPages(unittest.TestCase):
             check_series(self, series, programme_data['title'])
             for title in series['titles']:
                 self.assertTrue(title['premium'])
+        # Check episode - the data of the actual episode the page represents.
+        check_title(self, data['episode'], programme_data['title'])
+
 
     def test_film_details_page(self):
         page = fetch.get_document('https://www.itv.com/watch/a-day-to-remember/CFD0170')
@@ -680,6 +688,8 @@ class WatchPages(unittest.TestCase):
         self.assertEqual(1, len(data['seriesList']))
         self.assertEqual(1, len(data['seriesList'][0]['titles']))
         check_series(self, data['seriesList'][0], data['programme']['title'])
+        # Film pages do NOT have a field 'episode'
+        self.assertTrue('episode' not in data.keys())
 
     def test_special_details_page(self):
         page = fetch.get_document('https://www.itv.com/watch/how-to-catch-a-cat-killer/10a1951')
@@ -699,6 +709,7 @@ class WatchPages(unittest.TestCase):
         check_programme(self, data['programme'])
         # Just to flag when imagePresets in no longer present, like most other data structures.
         self.assertTrue('imagePresets' in data['programme'])
+        check_title(self, data['episode'], data['programme']['title'])
 
     def test_short_news_item(self):
         page = fetch.get_document('https://www.itv.com/watch/news/met-police-officers-investigated-for-gross-misconduct-over-stephen-port-case/fxmdtwy')
@@ -706,6 +717,9 @@ class WatchPages(unittest.TestCase):
         data = parsex.scrape_json(page)
         self.assertFalse('programme' in data)
         self.assertTrue('episode' in data)
+        # Episodes in short news is not completely conform title specs
+        self.assertRaises(AssertionError, check_title, self, data['episode'], 'short-news')
+        # Check is does have a field 'playlistUrl', so in can be used in main.play_title()
         self.assertTrue(is_url(data['episode']['playlistUrl']))
 
 


### PR DESCRIPTION
These items produce a playable item on the main page with an option 'view all episodes' in its context menu.