### PR TITLE
Optional full HD

### DIFF
--- a/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
@@ -85,6 +85,14 @@ msgctxt "#30133"
 msgid "Go to IPTV Manager settings"
 msgstr ""
 
+msgctxt "#30140"
+msgid "Stream quality"
+msgstr ""
+
+msgctxt "#30141"
+msgid "Enable full HD (1080p)"
+msgstr ""
+
 msgctxt "#30200"
 msgid "itvX account"
 msgstr ""
@@ -149,6 +157,11 @@ msgstr ""
 msgctxt "#30332"
 msgid "It may take a few hours before this setting takes effect.\n"
 "To force an update, select 'Refresh channels and guide now' in IPTV Manager's settings. You may also need te restart Kodi."
+msgstr ""
+
+msgctxt "#30341"
+msgid "May not work on all devices.\n"
+"When streams don't play, switch off to revert back to 720p HD."
 msgstr ""
 
 msgctxt "#30401"

--- a/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
@@ -73,6 +73,10 @@ msgctxt "#30121"
 msgid "Offer to play from the start"
 msgstr ""
 
+msgctxt "#30122"
+msgid "TV region"
+msgstr ""
+
 msgctxt "#30131"
 msgid "Install IPTV Manager"
 msgstr ""
@@ -152,6 +156,11 @@ msgstr ""
 msgctxt "#30321"
 msgid "Show a dialog with the option to play the current program from the start each time a live channel is being started.\n"
 "When disabled 'play form the start' is still available on the context menu of the main live channels."
+msgstr ""
+
+msgctxt "#30322"
+msgid "Region for local news and weather on ITV1.\n"
+"Only available when Full HD is enabled."
 msgstr ""
 
 msgctxt "#30332"

--- a/plugin.video.viwx/resources/lib/itv.py
+++ b/plugin.video.viwx/resources/lib/itv.py
@@ -56,65 +56,7 @@ def get_live_schedule(hours=4, local_tz=None):
     return schedule
 
 
-stream_req_data = {
-    'client': {
-        'id': 'browser',
-        'service': 'itv.x',
-        'supportsAdPods': False,
-        'version': '4.1'
-    },
-    'device': {
-        'manufacturer': 'Firefox',
-        'model': '127',
-        'os': {
-            'name': 'Linux',
-            'type': 'desktop',
-            'version': 'x86_64'
-        }
-    },
-    'user': {
-        'token': ''
-    },
-    'variantAvailability': {
-        'drm': {
-            'maxSupported': 'L3',
-            'system': 'widevine'
-        },
-        'featureset': ['mpeg-dash', 'widevine', 'outband-webvtt', 'hd', 'single-track'],
-        'platformTag': 'dotcom',
-        'player': 'dash'
-    }
-}
-
-
-def _request_stream_data(url, stream_type='live'):
-    from .itv_account import itv_session, fetch_authenticated
-    session = itv_session()
-
-    stream_req_data['user']['token'] = session.access_token
-    stream_req_data['client']['supportsAdPods'] = stream_type != 'live'
-
-    if stream_type == 'live':
-        accept_type = 'application/vnd.itv.online.playlist.sim.v3+json'
-        # Live MUST have a featureset containing an item without outband-webvtt, or a bad request is returned.
-        featureset = {'max': ['mpeg-dash', 'widevine'], 'min': ['mpeg-dash', 'widevine']}
-    else:
-        accept_type = 'application/vnd.itv.vod.playlist.v4+json'
-        # Contrary to live, catchup now has a single featureq set
-        featureset = ['mpeg-dash', 'widevine', 'outband-webvtt', 'hd', 'single-track']
-
-    stream_req_data['variantAvailability']['featureset'] = featureset
-
-    stream_data = fetch_authenticated(
-        fetch.post_json, url,
-        data=stream_req_data,
-        headers={'Accept': accept_type},
-        cookies=session.cookie)
-
-    return stream_data
-
-
-def get_live_urls(url=None, title=None, start_time=None, play_from_start=False):
+def get_live_urls(url=None, title=None, start_time=None, play_from_start=False, full_hd=False):
     """Return the urls to the dash stream, key service and subtitles for a particular live channel.
 
     .. note::
@@ -122,9 +64,10 @@ def get_live_urls(url=None, title=None, start_time=None, play_from_start=False):
         data returned by get_catchup_urls(...).
 
     """
-    channel = url.rsplit('/', 1)[1]
+    # import web_pdb; web_pdb.set_trace()
+    from . import itvx
 
-    stream_data = _request_stream_data(url)
+    stream_data = itvx._request_stream_data(url, full_hd=full_hd)
     video_locations = stream_data['Playlist']['Video']['VideoLocations'][0]
     dash_url = video_locations['Url']
     start_again_url = video_locations.get('StartAgainUrl')
@@ -133,9 +76,10 @@ def get_live_urls(url=None, title=None, start_time=None, play_from_start=False):
         if start_time and (play_from_start or kodi_utils.ask_play_from_start(title)):
             dash_url = start_again_url.format(START_TIME=start_time)
             logger.debug('get_live_urls - selected play from start at %s', start_time)
-        elif video_locations.get('IsDar'):
+        else:
             # Go 1 hour back to ensure we get the timeshift stream with adverts embedded
-            # and can skip back a bit in the stream.
+            # and can skip back a bit in the stream. Some FAST channels that do have a large
+            # enough buffer automatically use the maximum available time shift for that channel.
             start_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
             dash_url = start_again_url.format(START_TIME=start_time.strftime('%Y-%m-%dT%H:%M:%S'))
 
@@ -143,12 +87,13 @@ def get_live_urls(url=None, title=None, start_time=None, play_from_start=False):
     return dash_url, key_service, None
 
 
-def get_catchup_urls(episode_url):
+def get_catchup_urls(episode_url, full_hd=False):
     """Return the urls to the dash stream, key service and subtitles for a particular catchup
     episode and the type of video.
 
     """
-    playlist = _request_stream_data(episode_url, 'catchup')['Playlist']
+    from resources.lib import itvx
+    playlist = itvx._request_stream_data(episode_url, 'catchup', full_hd)['Playlist']
     stream_data = playlist['Video']
 
     # Select the media with the highest resolution

--- a/plugin.video.viwx/resources/lib/itv.py
+++ b/plugin.video.viwx/resources/lib/itv.py
@@ -82,7 +82,7 @@ def get_live_urls(url=None, title=None, start_time=None, play_from_start=False, 
             # enough buffer automatically use the maximum available time shift for that channel.
             start_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
             dash_url = start_again_url.format(START_TIME=start_time.strftime('%Y-%m-%dT%H:%M:%S'))
-
+    dash_url = dash_url.replace('ctv-low', 'ctv', 1)
     key_service = video_locations['KeyServiceUrl']
     return dash_url, key_service, None
 

--- a/plugin.video.viwx/resources/lib/itv_account.py
+++ b/plugin.video.viwx/resources/lib/itv_account.py
@@ -30,6 +30,7 @@ class ItvSession:
     def __init__(self):
         self._user_id = ''
         self._user_nickname = ''
+        self._tv_region = None
         self._expire_time = 0
         self.account_data = {}
         self.read_account_data()
@@ -63,6 +64,10 @@ class ItvSession:
     def user_nickname(self):
         return self._user_nickname or ''
 
+    @property
+    def tv_region(self):
+        return self._tv_region or ''
+
     def read_account_data(self):
         session_file = os.path.join(utils.addon_info.profile, "itv_session")
         logger.debug("Reading account data from file: %s", session_file)
@@ -82,7 +87,7 @@ class ItvSession:
         else:
             self.account_data = acc_data
         access_token = self.account_data.get('itv_session', {}).get('access_token')
-        self._user_id, self._user_nickname, self._expire_time = parse_token(access_token)
+        self.parse_token(access_token)
 
     def save_account_data(self):
         session_file = os.path.join(utils.addon_info.profile, "itv_session")
@@ -155,7 +160,7 @@ class ItvSession:
             raise
         else:
             logger.info("Sign in successful.")
-            self._user_id, self._user_nickname, self._expire_time = parse_token(session_data.get('access_token'))
+            self.parse_token(session_data.get('access_token'))
             self.save_account_data()
             return True
 
@@ -181,7 +186,7 @@ class ItvSession:
             sess_cookie_str = build_cookie(session_data)
             self.account_data['cookies']['Itv.Session'] = sess_cookie_str
             self.account_data['refreshed'] = time.time()
-            self._user_id, self._user_nickname, self._expire_time = parse_token(session_data.get('access_token'))
+            self.parse_token(session_data.get('access_token'))
             self.save_account_data()
             logger.info("Tokens refreshed.")
             return True
@@ -199,30 +204,36 @@ class ItvSession:
         self.save_account_data()
         self._user_id = None
         self._user_nickname = None
+        self._tv_region = None
         return True
 
+    def parse_token(self, token):
+        """Extract user_id, user nickname, region and token expiration time obtained from an access token.
 
-def parse_token(token):
-    """Return user_id, user nickname and token expiration time obtained from an access token.
-
-    Token has other fields which we currently don't parse, like:
-    accountProfileIdInUse
-    auth_time
-    scope
-    nonce
-    iat
-    """
-    import binascii
-    try:
-        token_parts = token.split('.')
-        # Since some padding errors have been observed with refresh tokens, add the maximum just
-        # to be sure padding errors won't occur. a2b_base64 automatically removes excess padding.
-        token_data = binascii.a2b_base64(token_parts[1] + '==')
-        data = json.loads(token_data)
-        return data['sub'], data['name'], data['exp']
-    except (KeyError, AttributeError, IndexError, binascii.Error) as err:
-        logger.error("Failed to parse token: '%r'", err)
-        return None, None, int(time.time()) + time.timezone
+        Token has other fields which we currently don't parse, like:
+        accountProfileIdInUse
+        auth_time
+        scope
+        nonce
+        iat
+        """
+        import binascii
+        from resources.lib import region
+        try:
+            token_parts = token.split('.')
+            # Apply the maximum padding; a2b_base64 ignores excess padding.
+            token_data = binascii.a2b_base64(token_parts[1] + '==')
+            data = json.loads(token_data)
+            self._user_id = data['sub']
+            self._user_nickname = data['name']
+            self._tv_region = region.tv_region(data['region'])
+            self._expire_time = data['exp'] - 1800
+        except (KeyError, AttributeError, IndexError, binascii.Error, json.JSONDecodeError) as err:
+            logger.error("Failed to parse token: '%r'", err)
+            self._user_id = None
+            self._user_nickname = None
+            self._tv_region = None
+            self._expire_time = int(time.time()) + time.timezone
 
 
 def build_cookie(session_data):

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -535,6 +535,13 @@ def play_stream_live(addon, channel, url=None, title=None, start_time=None, play
         url = 'https://simulcast.itv.com/playlist/itvonline/' + channel
         logger.info("Created live url from channel name: '%s'", url)
 
+    tv_region = addon.setting['tv_region']
+    if tv_region == 'by_account':
+        tv_region = itv_account.itv_session().tv_region
+    if tv_region:
+        # Only affects freeview streams, is currently ignored by web.
+        url = url + '?region=' + tv_region
+
     if addon.setting['live_play_from_start'] != 'true' and not play_from_start:
         start_time = None
     fhd_enabled = addon.setting['FHD_enabled'] == 'true'

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -537,11 +537,12 @@ def play_stream_live(addon, channel, url=None, title=None, start_time=None, play
 
     if addon.setting['live_play_from_start'] != 'true' and not play_from_start:
         start_time = None
-
+    fhd_enabled = addon.setting['FHD_enabled'] == 'true'
     manifest_url, key_service_url, subtitle_url = itv.get_live_urls(url,
                                                                     title,
                                                                     start_time,
-                                                                    play_from_start)
+                                                                    play_from_start,
+                                                                    fhd_enabled)
     list_item = create_dash_stream_item(channel, manifest_url, key_service_url)
     if list_item:
         if start_time and ('?t=' in manifest_url or '&t=' in manifest_url):
@@ -556,8 +557,9 @@ def play_stream_live(addon, channel, url=None, title=None, start_time=None, play
 def play_stream_catchup(plugin, url, name, set_resume_point=False):
 
     logger.info('play catchup stream - %s  url=%s', name, url)
+    fhd_enabled = plugin.setting['FHD_enabled'] == 'true'
     try:
-        manifest_url, key_service_url, subtitle_url, stream_type, production_id = itv.get_catchup_urls(url)
+        manifest_url, key_service_url, subtitle_url, stream_type, production_id = itv.get_catchup_urls(url, fhd_enabled)
         logger.debug('dash subtitles url: %s', subtitle_url)
     except AccessRestrictedError:
         logger.info('Stream only available with premium account')

--- a/plugin.video.viwx/resources/lib/region.py
+++ b/plugin.video.viwx/resources/lib/region.py
@@ -1,0 +1,36 @@
+# ----------------------------------------------------------------------------------------------------------------------
+#  Copyright (c) 2025 Dimitri Kroon.
+#  This file is part of plugin.video.viwx.
+#  SPDX-License-Identifier: GPL-2.0-or-later
+#  See LICENSE.txt
+# ----------------------------------------------------------------------------------------------------------------------
+
+region_map = {
+    "london": "london",
+    "meridian_east": "meridian_east",
+    "meridian_south_coast": "meridian_east",
+    "meridian_thames_valley": "meridian_east",
+    "channel_islands": "meridian_east",
+    "anglia_east": "meridian_east",
+    "anglia_west": "meridian_east",
+    "central_west": "central_west",
+    "central_east":  "central_west",
+    "west":  "central_west",
+    "west_country":  "central_west",
+    "wales": "wales",
+    "granada": "granada",
+    "border_england": "granada",
+    "border_scotland": "granada",
+    "tyne_tees": "granada",
+    "emley_moor": "granada",
+    "belmont": "granada",
+    "ulster": "ulster",
+}
+
+
+def tv_region(user_region):
+    """Convert a user's region to a TV region.
+
+    Used in live TV to get the correct regional news and weather.
+    """
+    return region_map.get(user_region, '')

--- a/plugin.video.viwx/resources/settings.xml
+++ b/plugin.video.viwx/resources/settings.xml
@@ -65,6 +65,31 @@
 					<default>false</default>
 					<control type="toggle" />
 				</setting>
+				<setting id="tv_region" label="30122" type="string" help="30322">
+					<level>0</level>
+					<default>by_account</default>
+					<constraints>
+						<options>
+                            <option label="By ITVX account">by_account</option>
+							<option label="Default">london</option>
+							<option label="London">london</option>
+							<option label="Meridian">meridian_east</option>
+							<option label="Central">central_west</option>
+							<option label="Wales">wales</option>
+							<option label="Granada">granada</option>
+							<option label="Ulster">ulster</option>
+						</options>
+						<allowempty>true</allowempty>
+					</constraints>
+					<dependencies>
+						<dependency type="enable" setting="FHD_enabled">true</dependency>
+					</dependencies>
+					<control type="list" format="string">
+						<heading>30122</heading>
+						<multiselect>false</multiselect>
+						<hidevalue>false</hidevalue>
+					</control>
+				</setting>
 				<setting id="install_iptvmanager" label="30131" type="action" help="">
 					<level>0</level>
 					<data>InstallAddon(service.iptv.manager)</data>

--- a/plugin.video.viwx/resources/settings.xml
+++ b/plugin.video.viwx/resources/settings.xml
@@ -3,6 +3,13 @@
     <section id="plugin.video.viwx">
         <!-- General -->
         <category id="general" label="30100" help="">
+			<group id="grp-strm-quality" label="30140">
+				<setting id="FHD_enabled" label="30141" type="boolean" help="30341">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
+			</group>
 			<group id="grp1" label="30101">
 				<setting id="subtitles_show" label="30102" type="boolean" help="30302">
 					<level>0</level>

--- a/test/local/test_account.py
+++ b/test/local/test_account.py
@@ -24,8 +24,8 @@ from resources.lib import fetch
 from resources.lib import utils
 
 from test.support.object_checks import has_keys
-from test.support.testutils import is_uuid
-from test.support.testutils import HttpResponse
+from test.support.testutils import is_uuid, HttpResponse, SessionMock
+
 
 # noinspection PyPep8Naming
 setUpModule = fixtures.setup_local_tests
@@ -34,7 +34,7 @@ tearDownModule = fixtures.tear_down_local_tests
 
 ACCESS_TKN_FIELDS = ('iss', 'sub', 'exp', 'iat', 'broadcastErrorMsg', 'broadcastResponseCode', 'broadcaster',
                      'isActive', 'nonce', 'name', 'scope', 'entitlements', 'paymentSource', 'showPrivacyNotice',
-                     'under18', 'accountProfileIdInUse')
+                     'under18', 'accountProfileIdInUse', 'region', 'postcodeValidatedOn', 'profileType')
 REFRESH_TKN_FIELDS = ('iss', 'sub', 'exp', 'iat', 'nonce', 'scope', 'auth_time', 'accountProfileIdInUse')
 PROFILE_TKN_FIELDS = ('iss', 'sub', 'exp', 'iat', 'nonce', 'name', 'under18', 'scope')
 
@@ -59,7 +59,10 @@ def build_test_tokens(user_nick, account_id=None, exp_time=None):
                 "paymentSource": "",
                 "showPrivacyNotice": False,
                 "under18": False,
-                "accountProfileIdInUse": None}
+                "accountProfileIdInUse": None,
+                "region": "border_england",
+                "postcodeValidatedOn": 1751882688768,
+                "profileType": "main"}
 
     def create_token(tkn_data, key):
         return '.'.join((
@@ -339,6 +342,28 @@ class PropUserNickName(unittest.TestCase):
         self.assertEqual('', sess.user_nickname)
 
 
+class PropTvRegion(unittest.TestCase):
+    def test_prop_tv_region(self):
+        acc_data = deepcopy(account_data_v2)
+        acc_data['itv_session'] = session_dta['itv_session']
+        with patch('resources.lib.itv_account.open', mock_open(read_data=json.dumps(acc_data))):
+            sess = SessionMock()
+        self.assertEqual('granada', sess.tv_region)
+        sess.log_out()
+        self.assertEqual('', sess.tv_region)
+        # The absence of tv_region does not trigger a login or refresh.
+        sess.login.assert_not_called()
+        sess.refresh.assert_not_called()
+
+    def test_prop_tv_region_not_logged_in(self):
+        with patch('resources.lib.itv_account.open', side_effect=IOError):
+            sess = SessionMock()
+        self.assertEqual('', sess.tv_region)
+        # The absence of tv_region does not trigger a login or refresh.
+        sess.login.assert_not_called()
+        sess.refresh.assert_not_called()
+
+
 class Misc(unittest.TestCase):
     def test_read_account_data(self):
         with patch('resources.lib.itv_account.open', mock_open(read_data=json.dumps(account_data_v2))):
@@ -391,20 +416,24 @@ class Misc(unittest.TestCase):
         self.assertEqual('', ct_sess.user_id)
         self.assertEqual('', ct_sess.user_nickname)
 
-    def test_parse_token(self):
+    @patch('resources.lib.itv_account.ItvSession.read_account_data')
+    def test_parse_token(self, _):
         access_tkn, _, __ = build_test_tokens('My username')
-        a_user_id, a_user_nick, a_exp_time = itv_account.parse_token(access_tkn)
-        self.assertTrue(is_uuid(a_user_id))
-        self.assertIsInstance(a_exp_time, int)
-        self.assertEqual('My username', a_user_nick)
+        sess = itv_account.ItvSession()
+        sess.parse_token(access_tkn)
+        self.assertTrue(is_uuid(sess.user_id))
+        self.assertIsInstance(sess._expire_time, int)
+        self.assertEqual('My username', sess.user_nickname)
+        self.assertEqual('granada', sess.tv_region)
 
-        invalid_token = access_tkn[:60] + access_tkn[90:]
-        a_user_id, a_user_nick, a_exp_time = itv_account.parse_token(invalid_token)
-        self.assertIsNone(a_user_id)
-        self.assertIsNone(a_user_nick)
+        invalid_token = access_tkn[:60] + access_tkn[92:]
+        sess.parse_token(invalid_token)
+        self.assertEqual('', sess.user_id)
+        self.assertEqual('', sess.user_nickname)
+        self.assertEqual('', sess.tv_region)
         # on parse errors expire time is set to now(), to force a refresh on the next call
-        self.assertIsInstance(a_exp_time, int)
-        self.assertAlmostEqual(a_exp_time, time.time() + time.timezone, delta=1)
+        self.assertIsInstance(sess._expire_time, int)
+        self.assertAlmostEqual(sess._expire_time, time.time() + time.timezone, delta=1)
 
 
 class AccountMock:

--- a/test/local/test_itv.py
+++ b/test/local/test_itv.py
@@ -60,16 +60,8 @@ class LiveSchedule(TestCase):
             self.assertEqual('07:30 pm', start_time.lower())
 
 
-class RequestStreamData(TestCase):
-    def test_request_with_auth_failure(self):
-        with patch.object(itv_account.itv_session(), 'account_data', {}):
-            with self.assertRaises(SystemExit) as cm:
-                itv._request_stream_data('some/url')
-            self.assertEqual(1, cm.exception.code)
-
-
 class GetCatchupUrls(TestCase):
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
     def test_catchup_urls(self, _):
         mpd, key, subs, video_type, prod_id = itv.get_catchup_urls('itv1/url')
         self.assertTrue(is_url(mpd))
@@ -77,7 +69,7 @@ class GetCatchupUrls(TestCase):
         self.assertTrue(is_url(subs))
         self.assertEqual(video_type, 'CATCHUP')
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_news_short.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_news_short.json'))
     def test_shorform_urls(self, _):
         mpd, key, subs, video_type, prod_id = itv.get_catchup_urls('itv1/url')
         self.assertTrue(is_url(mpd))
@@ -87,7 +79,7 @@ class GetCatchupUrls(TestCase):
 
 
 class GetLiveUrls(TestCase):
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
     def test_get_dar_urls(self, _):
         mpd, key, subs = itv.get_live_urls('itv1/url')
         self.assertTrue(is_url(mpd))
@@ -95,16 +87,7 @@ class GetLiveUrls(TestCase):
         self.assertTrue(is_url(key))
         self.assertIsNone(subs)
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_fast_non_dar.json'))
-    def test_get_non_dar_urls(self, _):
-        # Only DAAR live stremas use the startagain url
-        mpd, key, subs = itv.get_live_urls('itv.com/FAST15')
-        self.assertTrue(is_url(mpd))
-        self.assertFalse('?t=' in mpd)
-        self.assertTrue(is_url(key))
-        self.assertIsNone(subs)
-
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
     def test_get_live_urls_start_again(self, _):
         mpd, key, subs = itv.get_live_urls('itv1/url', start_time='2023-05-06T17:18:32Z', play_from_start=True)
         self.assertTrue(is_url(mpd))
@@ -116,7 +99,7 @@ class GetLiveUrls(TestCase):
         playlist = open_json('playlists/pl_itv1.json')
         for item in playlist['Playlist']['Video']['VideoLocations']:
             del item['StartAgainUrl']
-        with patch('resources.lib.itv._request_stream_data', return_value=playlist):
+        with patch('resources.lib.itvx._request_stream_data', return_value=playlist):
             mpd, key, subs = itv.get_live_urls('itv1/url', start_time='2023-05-06T17:18:32Z', play_from_start=True)
         self.assertTrue(is_url(mpd))
         self.assertFalse('?t=' in mpd)

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -469,7 +469,7 @@ class CreateDashStreamItem(TestCase):
 
 
 class PlayStreamLive(TestCase):
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
     @patch('requests.get', return_value=HttpResponse())
     @patch('resources.lib.itv_account.ItvSession.refresh', return_value=True)
     @patch('resources.lib.itv_account.ItvSession.cookie', new={'Itv.Session': 'blabla'})
@@ -519,12 +519,12 @@ class PlayStreamCatchup(TestCase):
         # Ensure to clear patched session objects
         itv_account._itv_session_obj = None
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_news_short.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_news_short.json'))
     def test_play_short_news_item(self, _):
         result = main.play_stream_catchup.test('some/url', 'a short news item')
         self.assertIsInstance(result, XbmcListItem)
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
     @patch('requests.get', return_value=HttpResponse())
     @patch('resources.lib.itv_account.ItvSession.cookie', new={'Itv.Session': ''})
     def test_play_episode(self, _, __):
@@ -537,7 +537,7 @@ class PlayStreamCatchup(TestCase):
         self.assertFalse('IsPlayable' in result._props)
         self.assertRaises(AttributeError, getattr, result, '_subtitles')
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
     @patch('requests.get', return_value=HttpResponse())
     @patch('resources.lib.itv_account.ItvSession.cookie', new={'Itv.Session': ''})
     def test_play_episode_without_title(self, _, __):
@@ -547,21 +547,21 @@ class PlayStreamCatchup(TestCase):
         with self.assertRaises(KeyError):
             result._info['video']['title']
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
     @patch('resources.lib.main.create_dash_stream_item', return_value=XbmcListItem())
     @patch('resources.lib.itv.get_vtt_subtitles', return_value=('my/subs.file', ))
     def test_play_episode_with_subtitles(self, _, __, ___):
         result = main.play_stream_catchup.test('some/url', 'my episode')
         self.assertEqual(len(result._subtitles), 1)
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
     @patch('resources.lib.main.create_dash_stream_item', return_value=XbmcListItem())
     @patch('resources.lib.itv.get_vtt_subtitles', return_value=None)
     def test_play_episode_without_subtitles(self, _, __, ___):
         result = main.play_stream_catchup.test('some/url', 'my episode')
         self.assertRaises(AttributeError, getattr, result, '_subtitles')
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
     @patch('resources.lib.main.create_dash_stream_item', return_value=xbmcgui.ListItem())
     @patch('resources.lib.itvx.get_resume_point', return_value=32)
     def test_play_episode_with_resume(self, _, __, ___):
@@ -586,7 +586,7 @@ class PlayStreamCatchup(TestCase):
     def test_play_catchup_with_other_error(self, _):
         self.assertRaises(ValueError, main.play_stream_catchup.test, 'url', '')
 
-    @patch('resources.lib.itv._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
+    @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_doc_martin.json'))
     @patch('resources.lib.main.create_dash_stream_item', return_value=False)
     def test_play_catchup_inputstream_adaptive_not_installed(self, _, __):
         result = main.play_stream_catchup.test('url', '')

--- a/test/web/test_itv_account.py
+++ b/test/web/test_itv_account.py
@@ -84,6 +84,7 @@ class TestTokens(unittest.TestCase):
         self._check_token_type(token_data[0])
         user_data = token_data[1]
         object_checks.has_keys(user_data, *ACCESS_TKN_FIELDS)
+        self.assertEqual(len(user_data), len(ACCESS_TKN_FIELDS))
         self.assertTrue(user_data['isActive'])
         self.assertEqual('https://auth.itv.com', user_data['iss'])  # issuer
         self.assertTrue(testutils.is_uuid(user_data['sub']))

--- a/test/web/test_itvx.py
+++ b/test/web/test_itvx.py
@@ -17,8 +17,8 @@ from codequick import Route
 
 from resources.lib import itvx, itv_account
 from resources.lib import cache
-from test.support.object_checks import is_url, has_keys, is_li_compatible_dict
-
+from test.support.object_checks import (is_url, has_keys, is_li_compatible_dict,
+                                        check_catchup_dash_stream_info, check_live_stream_info)
 setUpModule = fixtures.setup_web_test
 
 
@@ -130,3 +130,15 @@ class TestItvX(unittest.TestCase):
         for chan in guide.values():
             self.assertIsInstance(chan, list)
             self.assertGreater(len(chan), 300)
+
+    def test__request_stream_data_vod(self):
+        urls = (
+            # something else with subtitles:
+            'https://magni.itv.com/playlist/itvonline/ITV/10_0852_0001.001', )
+        for url in urls:
+            result = itvx._request_stream_data(url, 'vod')
+            check_catchup_dash_stream_info(result['Playlist'])
+
+    def test__request_stream_data_live(self):
+        result = itvx._request_stream_data('https://simulcast.itv.com/playlist/itvonline/ITV', 'live')
+        check_live_stream_info(result['Playlist'])

--- a/test/web/test_itvx.py
+++ b/test/web/test_itvx.py
@@ -136,8 +136,10 @@ class TestItvX(unittest.TestCase):
             # something else with subtitles:
             'https://magni.itv.com/playlist/itvonline/ITV/10_0852_0001.001', )
         for url in urls:
-            result = itvx._request_stream_data(url, 'vod')
-            check_catchup_dash_stream_info(result['Playlist'])
+            result = itvx._request_stream_data(url, stream_type='vod', full_hd=False)
+            check_catchup_dash_stream_info(result['Playlist'], full_hd=False)
+            result = itvx._request_stream_data(url, stream_type='vod', full_hd=True)
+            check_catchup_dash_stream_info(result['Playlist'], full_hd=True)
 
     def test__request_stream_data_live(self):
         result = itvx._request_stream_data('https://simulcast.itv.com/playlist/itvonline/ITV', 'live')

--- a/test/web/test_itvx_api.py
+++ b/test/web/test_itvx_api.py
@@ -574,6 +574,70 @@ stream_req_data = {
     }
 }
 
+mobile_strm_req_data = {
+  "client": {
+    "id": "android",
+    "service": "itv.x",
+    "supportsAdPods": False,
+    "version": "0.6.0"
+  },
+  "device": {
+    "advertisingIdentifier": "00000000-0000-0000-0000-000000000000",
+    "firmware": "22",
+    "id": "xplayer",
+    "manufacturer": "",
+    "model": "",
+    "os": {
+      "name": "android",
+      "type": "android",
+      "version": "12.0"
+    }
+  },
+  "preview": False,
+  "user": {
+    "entitlements": [],
+    "itvUserId": "",
+    "status": "reg",
+    "subscribed": "false",
+    "token": ""
+  },
+  "variantAvailability": {
+    "featureset": {
+
+    },
+    "platformTag": "ctv"
+  }
+}
+
+features_live = {
+    "min": [
+        "mpeg-dash",
+        "widevine",
+      ],
+    "max": [
+        "hd",
+        "mpeg-dash",
+        "widevine",
+        "inband-webvtt"
+    ]
+}
+
+features_catchup = {
+    "min": [
+        "hd",
+        "mpeg-dash",
+        "widevine",
+        "single-track",
+        "outband-webvtt"
+      ],
+    "max": [
+        "hd",
+        "mpeg-dash",
+        "widevine",
+        "single-track",
+        "outband-webvtt"
+    ]
+}
 
 class Playlists(unittest.TestCase):
     manifest_headers = {
@@ -583,7 +647,7 @@ class Playlists(unittest.TestCase):
     @staticmethod
     def create_post_data(stream_type):
         acc_data = itv_account.itv_session()
-        post_data = copy.deepcopy(stream_req_data)
+        post_data = copy.deepcopy(mobile_strm_req_data)
         post_data['user']['token'] = acc_data.access_token
         post_data['client']['supportsAdPods'] = True
 
@@ -680,10 +744,15 @@ class Playlists(unittest.TestCase):
 
         resp = requests.post(
             url,
-            headers={'Accept': 'application/vnd.itv.vod.playlist.v4+json',
-                     'User-Agent': fetch.USER_AGENT,
-                     'Origin': 'https://www.itv.com',
+            headers={'Accept': 'application/vnd.itv.vod.playlist.v2+json',
+                     'User-Agent': 'X-Player',
+                     # 'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0 ',
+                     # 'Origin': 'https://www.itv.com',
                      },
+            # headers={'Accept': 'application/vnd.itv.vod.playlist.v2+json',
+            #          'User-Agent': 'ITV_Player_(Android)',
+            #          'Origin': 'https://www.itv.com',
+            #          },
             json=post_data,
             timeout=10)
         resp = resp.json()

--- a/test/web/test_itvx_api.py
+++ b/test/web/test_itvx_api.py
@@ -14,8 +14,6 @@ import copy
 from datetime import datetime, timedelta, timezone
 
 import requests
-from requests.cookies import RequestsCookieJar
-from urllib.parse import quote
 
 from resources.lib import itv_account
 from resources.lib import fetch
@@ -237,7 +235,7 @@ class MyList(unittest.TestCase):
         cls.mylist_url = ('https://my-list.prd.user.itv.com/user/{}/mylist?features=mpeg-dash,outband-webvtt,'
                           'hls,aes,playready,widevine,fairplay,progressive&platform=ctv&size=52').format(cls.userid)
         # Both webbrowser and app authenticate with a header, no cookies required.
-        cls.headers =  {'authorization': 'Bearer ' + cls.token}
+        cls.headers = {'authorization': 'Bearer ' + cls.token}
 
     def test_get_my_list_no_content_type(self):
         """Request My List without specifying the content-type
@@ -545,7 +543,7 @@ class Recommended(unittest.TestCase):
 # ----------------------------------------------------------------------------------------------------------------------
 
 
-stream_req_data = {
+web_req_data = {
     'client': {
         'id': 'browser',
         'supportsAdPods': False,
@@ -574,7 +572,7 @@ stream_req_data = {
     }
 }
 
-mobile_strm_req_data = {
+mobile_req_data = {
   "client": {
     "id": "android",
     "service": "itv.x",
@@ -602,11 +600,33 @@ mobile_strm_req_data = {
     "token": ""
   },
   "variantAvailability": {
-    "featureset": {
-
-    },
+    "featureset": {},
     "platformTag": "ctv"
   }
+}
+
+freeview_req_data = {
+    "client": {
+        "id": "freeview",
+        "isp": {},
+        "supportsAdPods": True,
+        "appVersion": "3.564.0",
+        "version": "3.564.0",
+        "service": "itv.x",
+        "thirdPartyPaymentModel": "free",
+        "ssaiClientSdkVersion": "3"
+    },
+    "device": {
+        "manufacturer": "LG",
+        "model": "oled77g36la",
+        "os": {"name": "oled77g36la"}
+    },
+    "user": {"token": ""},
+    "variantAvailability": {
+        "featureset": {},
+        "platformTag": "ctv",
+        "drm": {"system": "widevine", "maxSupported": "L3"}
+    }
 }
 
 features_live = {
@@ -622,45 +642,36 @@ features_live = {
     ]
 }
 
-features_catchup = {
-    "min": [
-        "hd",
-        "mpeg-dash",
-        "widevine",
-        "single-track",
-        "outband-webvtt"
-      ],
-    "max": [
-        "hd",
-        "mpeg-dash",
-        "widevine",
-        "single-track",
-        "outband-webvtt"
-    ]
-}
+features_catchup = ['mpeg-dash', 'widevine', 'outband-webvtt', 'hd', 'single-track']
+
 
 class Playlists(unittest.TestCase):
     manifest_headers = {
         'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0 ',
         'Origin': 'https://www.itv.com'}
 
-    @staticmethod
-    def create_post_data(stream_type):
-        acc_data = itv_account.itv_session()
-        post_data = copy.deepcopy(mobile_strm_req_data)
-        post_data['user']['token'] = acc_data.access_token
+    @classmethod
+    def setUpClass(cls):
+        cls.acc_data = itv_account.itv_session()
+        cls.acc_data.refresh()
+
+    def create_post_data(self, stream_type, platform='freeview'):
+        req_data = {
+            'web': web_req_data,
+            'mobile': mobile_req_data,
+            'freeview': freeview_req_data
+        }.get(platform)
+        post_data = copy.deepcopy(req_data)
+        post_data['user']['token'] = self.acc_data.access_token
         post_data['client']['supportsAdPods'] = True
 
-        # Live has still the old style feature set with min and max sets.
         if stream_type == 'live':
-            post_data['variantAvailability']['featureset']= {
-                'max': ['mpeg-dash', 'widevine'],
-                'min': ['mpeg-dash', 'widevine']
-            }
-
+            post_data['variantAvailability']['featureset'] = features_live
+        else:
+            post_data['variantAvailability']['featureset'] = features_catchup
         return post_data
 
-    def get_playlist_live(self, channel):
+    def get_playlist_live(self, channel, platform='freeview'):
         """Get the playlist of one of the itvx live channels
 
         For all channels no other headers than User Agent and Origin are required.
@@ -668,9 +679,7 @@ class Playlists(unittest.TestCase):
 
         Since accessToken is provided in the body, authentication by cookie or header is not needed.
         """
-        acc_data = itv_account.itv_session()
-        acc_data.refresh()
-        post_data = self.create_post_data('live')
+        post_data = self.create_post_data('live', platform)
 
         url = 'https://simulcast.itv.com/playlist/itvonline/' + channel
         resp = requests.post(
@@ -683,60 +692,102 @@ class Playlists(unittest.TestCase):
         strm_data = resp.json()
         return strm_data
 
-    def test_get_playlist_simulcast(self):
-        for channel in ('ITV', 'ITV2', 'ITV3', 'ITV4', 'CITV', 'ITVBe'):
-            strm_data = self.get_playlist_live(channel)
-            # testutils.save_json(strm_data, 'playlists/pl_itv1.json')
-            object_checks.check_live_stream_info(strm_data['Playlist'])
-
-    def test_get_playlist_fast(self):
-        for chan_id in range(20, 21):
-            channel = 'FAST{}'.format(chan_id)
-            strm_data = self.get_playlist_live(channel)
-            # if chan_id == 20:
-            #     testutils.save_json(strm_data, 'playlists/pl_fast_non_dar.json')
-            object_checks.check_live_stream_info(strm_data['Playlist'])
-
-    def test_manifest_live_simulcast(self):
-        strm_data = self.get_playlist_live('ITV')
-        start_again_url = strm_data['Playlist']['Video']['VideoLocations'][0]['StartAgainUrl']
-        start_time = datetime.now(timezone.utc) - timedelta(seconds=30)
+    def get_manifest_live(self, channel, platform):
+        """Get the manifest from the start-again url"""
+        playlist = self.get_playlist_live(channel, platform)
+        start_again_url = playlist['Playlist']['Video']['VideoLocations'][0]['StartAgainUrl']
+        start_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
         mpd_url = start_again_url.format(START_TIME=start_time.strftime('%Y-%m-%dT%H:%M:%S'))
         resp = requests.get(mpd_url, headers=self.manifest_headers, timeout=10)
         manifest = resp.text
+        return manifest
+
+    def test_get_playlist_simulcast_web(self):
+        for channel in ('ITV', 'ITV2', 'ITV3', 'ITV4', 'ITVBe'):
+            strm_data = self.get_playlist_live(channel, 'web')
+            # testutils.save_json(strm_data, 'playlists/pl_itv1.json')
+            object_checks.check_live_stream_info(strm_data['Playlist'], full_hd=False)
+
+    def test_get_playlist_simulcast_freeview(self):
+        for channel in ('ITV', 'ITV2', 'ITV4'):
+            strm_data = self.get_playlist_live(channel, 'freeview')
+            # testutils.save_json(strm_data, 'playlists/pl_itv1.json')
+            object_checks.check_live_stream_info(strm_data['Playlist'], full_hd=True)
+        for channel in ('ITV3', 'ITVBe'):
+            strm_data = self.get_playlist_live(channel, 'freeview')
+            object_checks.check_live_stream_info(strm_data['Playlist'], full_hd=False)
+            self.assertFalse(strm_data['Playlist']['Video']['VideoLocations'][0]['IsDar'])
+
+    def test_get_playlist_fast_web(self):
+        for chan_id in (5, 20):
+            channel = 'FAST{}'.format(chan_id)
+            strm_data = self.get_playlist_live(channel, 'web')
+            # if chan_id == 20:
+            #     testutils.save_json(strm_data, 'playlists/pl_fast_non_dar.json')
+            object_checks.check_live_stream_info(strm_data['Playlist'], full_hd=False)
+            if chan_id == 20:
+                # FAST20 - GoUSA TV is always non-dar
+                self.assertFalse(strm_data['Playlist']['Video']['VideoLocations'][0]['IsDar'])
+            else:
+                self.assertTrue(strm_data['Playlist']['Video']['VideoLocations'][0]['IsDar'])
+
+    def test_get_playlist_fast_freeview(self):
+        """Freeview fast channels are 720p by default"""
+        for chan_id in (5, 20):
+            channel = 'FAST{}'.format(chan_id)
+            strm_data = self.get_playlist_live(channel, 'freeview')
+            object_checks.check_live_stream_info(strm_data['Playlist'], full_hd=False)
+            # All freeview live streams are non-dar
+            self.assertFalse(strm_data['Playlist']['Video']['VideoLocations'][0]['IsDar'])
+
+    def test_manifest_live_simulcast_web(self):
+        manifest = self.get_manifest_live('ITV', 'web')
         # testutils.save_doc(manifest, 'mpd/itv1.mpd')
-        self.assertGreater(len(manifest), 1000)
-        self.assertTrue(manifest.startswith('<?xml version='))
+        max_res = object_checks.check_dash_manifest(self, manifest)
+        self.assertEqual(720, max_res)
+
+    def test_manifest_live_simulcast_freeview(self):
+        manifest = self.get_manifest_live('ITV', 'freeview')
+        max_res = object_checks.check_dash_manifest(self, manifest)
+        self.assertEqual(1080, max_res)
 
     def test_manifest_live_FAST(self):
-        strm_data = self.get_playlist_live('FAST16')
-        mpd_url = strm_data['Playlist']['Video']['VideoLocations'][0]['Url']
-        resp = requests.get(mpd_url, headers=self.manifest_headers, timeout=10)
-        manifest = resp.text
-        # testutils.save_doc(manifest, 'mpd/fast16.mpd')
-        self.assertGreater(len(manifest), 1000)
-        self.assertTrue(manifest.startswith('<?xml version='))
+        """NOTE: FAST channels change frequently, some channels may not return a valid manifest."""
+        for chan in ('5', '16', '20'):
+            manifest = self.get_manifest_live('FAST' + chan, 'web')
+            max_res = object_checks.check_dash_manifest(self, manifest)
+            self.assertEqual(720, max_res)
+            manifest = self.get_manifest_live('FAST' + chan, 'freeview')
+            max_res = object_checks.check_dash_manifest(self, manifest)
+            self.assertEqual(720, max_res)
 
-    def test_manifest_live_FAST_playagain(self):
-        """As of appr. mid 2024 play-again works again on FAST channels, although non
-        DAR channels never play more than appr. 5 minutes from the live edge.
+    def test_force_freeview_full_hd(self):
+        """On freeview only the ITV1, ITV2 and ITV4 are in full HD by default.
+        Test if we can obtain the other channels in 1080P as well by replacing
+        'ctv_low' with 'ctv' in the manifest url.
+
+        .. note ::
+            Fast channels change often and some might not be available any more.
         """
-        strm_data = self.get_playlist_live('FAST16')
-        start_time = datetime.strftime(datetime.now(timezone.utc) - timedelta(seconds=20), '%Y-%m-%dT%H:%M:%S')
-        mpd_url = strm_data['Playlist']['Video']['VideoLocations'][0]['StartAgainUrl'].format(START_TIME=start_time)
-        resp = requests.get(mpd_url, headers=self.manifest_headers, cookies=fetch.HttpSession().cookies)
-        self.assertEqual(200, resp.status_code)
-        manifest = resp.text
-        # testutils.save_doc(manifest, 'mpd/fast16.mpd')
-        self.assertGreater(len(manifest), 1000)
-        self.assertTrue(manifest.startswith('<?xml version='))
+        for channel in ('ITV3', 'FAST5', 'FAST20'):
+            playlist = self.get_playlist_live(channel, 'freeview')
+            start_again_url = playlist['Playlist']['Video']['VideoLocations'][0]['StartAgainUrl']
+            self.assertTrue('ctv-low.mpd' in start_again_url)
+            start_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
+            mpd_url = start_again_url.replace('ctv-low', 'ctv').format(START_TIME=start_time.strftime('%Y-%m-%dT%H:%M:%S'))
+            resp = requests.get(mpd_url, headers=self.manifest_headers, timeout=10)
+            max_res = object_checks.check_dash_manifest(self, resp.text)
+            self.assertEqual(1080, max_res)
 
-    def get_playlist_catchup(self, url=None):
+    # -----------------------
+    #       VOD
+    # -----------------------
+
+    def get_playlist_catchup(self, url=None, platform='freeview'):
         """Request stream of a catchup episode (i.e. production)
 
-        Unlike live channels, pLaylist requests for VOD don't need any cookie.
         """
-        post_data = self.create_post_data('vod')
+        post_data = self.create_post_data('vod', platform)
 
         if not url:
             # request playlist of an episode of Doc Martin
@@ -744,12 +795,12 @@ class Playlists(unittest.TestCase):
 
         resp = requests.post(
             url,
-            headers={'Accept': 'application/vnd.itv.vod.playlist.v2+json',
+            headers={'Accept': 'application/vnd.itv.vod.playlist.v4+json',
                      'User-Agent': 'X-Player',
                      # 'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0 ',
                      # 'Origin': 'https://www.itv.com',
                      },
-            # headers={'Accept': 'application/vnd.itv.vod.playlist.v2+json',
+            # headers={'Accept': 'application/vnd.itv.vod.playlist.v4+json',
             #          'User-Agent': 'ITV_Player_(Android)',
             #          'Origin': 'https://www.itv.com',
             #          },
@@ -759,48 +810,59 @@ class Playlists(unittest.TestCase):
         return resp
 
     def test_get_playlist_catchup(self):
-        strm_data = self.get_playlist_catchup()
+        strm_data = self.get_playlist_catchup(platform='web')
         # testutils.save_json(strm_data, 'playlists/pl_doc_martin.json')
-        object_checks.check_catchup_dash_stream_info(strm_data['Playlist'])
+        object_checks.check_catchup_dash_stream_info(strm_data['Playlist'], full_hd=False)
+        strm_data = self.get_playlist_catchup(platform='freeview')
+        object_checks.check_catchup_dash_stream_info(strm_data['Playlist'], full_hd=True)
 
     def test_get_playlist_premium_catchup(self):
-        """Request a premium stream without a premium account."""
+        """Request a premium stream _without_ a premium account."""
         # Judge John Deed S1E1
         resp = self.get_playlist_catchup('https://magni.itv.com/playlist/itvonline/ITV/10_5323_0001.001')
         object_checks.has_keys(resp, 'Message', 'TransactionId')
         self.assertTrue('message: User does not have entitlements' in resp['Message'])
 
     def test_manifest_vod(self):
-        strm_data = self.get_playlist_catchup()
-        mpd_url = strm_data['Playlist']['Video']['MediaFiles'][0]['Href']
-        resp = requests.get(mpd_url, headers=self.manifest_headers, timeout=10)
-        manifest = resp.text
-        self.assertGreater(len(manifest), 1000)
-        self.assertTrue(manifest.startswith('<?xml version='))
+        for platform in ('web', 'freeview'):
+            strm_data = self.get_playlist_catchup(platform=platform)
+            mpd_url = strm_data['Playlist']['Video']['MediaFiles'][0]['Href']
+            resp = requests.get(mpd_url, headers=self.manifest_headers, timeout=10)
+            max_res = object_checks.check_dash_manifest(self, resp.text)
+            if platform == 'web':
+                self.assertEqual(720, max_res)
+            else:
+                self.assertEqual(1080, max_res)
 
     def test_playlist_news_collection_items(self):
         """Short news items form the collection 'news' are all just mp4 files."""
         page_data = parsex.scrape_json(fetch.get_document('https://www.itv.com/'))
+        checked_types = set()
         for item in page_data['shortFormSliderContent'][0]['items']:
-            is_short = True
-            if 'encodedProgrammeId' in item.keys():
+            content_type = item['contentType']
+            if content_type in checked_types:
+                continue
+            checked_types.add(content_type)
+            if content_type == 'shortform':
+                url = '/'.join(('https://www.itv.com/watch/news', item['titleSlug'], item['episodeId']))
+            elif 'encodedProgrammeId' in item.keys():
                 # The new item is a 'normal' catchup title
-                # Do not use field 'href' as it has non-a-encoded program and episode Id's which won't work.
+                # Do not use field 'href' as it has non-a-encoded program and episode IDs which won't work.
                 url = '/'.join(('https://www.itv.com/watch',
                                 item['titleSlug'],
                                 item['encodedProgrammeId']['letterA'],
                                 item.get('encodedEpisodeId', {}).get('letterA', ''))).rstrip('/')
-                is_short = False
             else:
-                # This news item is a 'short' item
-                url = '/'.join(('https://www.itv.com/watch/news', item['titleSlug'], item['episodeId']))
+                raise AssertionError("Unknown news item type '{}'.".format(content_type))
+
             playlist_url = itvx.get_playlist_url_from_episode_page(url)
-            strm_data = self.get_playlist_catchup(playlist_url)
-            # testutils.save_json(strm_data, 'playlists/pl_news_short.json')
-            if is_short:
-                object_checks.check_news_collection_stream_info(strm_data['Playlist'])
-            else:
-                object_checks.check_catchup_dash_stream_info(strm_data['Playlist'])
+            for platform in ('web', 'freeview'):
+                strm_data = self.get_playlist_catchup(playlist_url, platform)
+                # testutils.save_json(strm_data, 'playlists/pl_news_short.json')
+                if content_type == 'shortform':
+                    object_checks.check_news_collection_stream_info(strm_data['Playlist'])
+                else:
+                    object_checks.check_catchup_dash_stream_info(strm_data['Playlist'], full_hd=platform == 'freeview')
 
 
 class ChannelLogos(unittest.TestCase):

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -150,7 +150,7 @@ class TestGetProductions(unittest.TestCase):
 
 class TestPlayCatchup(unittest.TestCase):
     def test_play_itv_1(self):
-        result = main.play_stream_live(MagicMock(), "itv", 'https://simulcast.itv.com/playlist/itvonline/itv', None)
+        result = main.play_stream_live.test("itv", 'https://simulcast.itv.com/playlist/itvonline/itv', None)
         self.assertEqual('itv', result.getLabel())
         self.assertIsInstance(result, XbmcListItem)
 


### PR DESCRIPTION
Fixes #144

Both live and VOD streams are now available at a resolution of 1920x1080 when viwX's new setting 'Enable Full HDl' is enabled.
Since full HD does not work on all systems the setting is disabled by default, resulting in the traditional 720p web streams.

All thanks to the info provided by @CasperMcFadden95  in #144

Please note that short news and sport clips will always be in 720p.