### PR TITLE
Removed setting "Offer to play from the start".

### DIFF
--- a/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
+++ b/plugin.video.viwx/resources/language/resource.language.en_gb/strings.po
@@ -69,9 +69,6 @@ msgctxt "#30120"
 msgid "Live channels"
 msgstr ""
 
-msgctxt "#30121"
-msgid "Offer to play from the start"
-msgstr ""
 
 msgctxt "#30122"
 msgid "TV region"
@@ -153,10 +150,7 @@ msgid "Target of viwX logging.\n"
 "'No logging' if you want to ensure the addon spends as little time on logging as possible."
 msgstr ""
 
-msgctxt "#30321"
-msgid "Show a dialog with the option to play the current program from the start each time a live channel is being started.\n"
-"When disabled 'play form the start' is still available on the context menu of the main live channels."
-msgstr ""
+
 
 msgctxt "#30322"
 msgid "Region for local news and weather on ITV1.\n"

--- a/plugin.video.viwx/resources/lib/cleanup.py
+++ b/plugin.video.viwx/resources/lib/cleanup.py
@@ -1,0 +1,43 @@
+# ----------------------------------------------------------------------------------------------------------------------
+#  Copyright (c) 2025 Dimitri Kroon.
+#  This file is part of plugin.video.viwx.
+#  SPDX-License-Identifier: GPL-2.0-or-later
+#  See LICENSE.txt
+# ----------------------------------------------------------------------------------------------------------------------
+import xbmcvfs
+import os
+import logging
+from xml.etree.ElementTree import ElementTree
+
+from codequick.support import logger_id
+
+
+logger = logging.getLogger(logger_id + '.cleanup')
+
+
+def remove_setting_value(profile_dir, *setting_ids: str):
+    """Remove one or more setting values from the user's profile.
+
+    Intended to be able to remove the value of a setting that is no longer
+    available in de add-on's settings.
+
+    """
+    fname = profile_dir
+    try:
+        fname = xbmcvfs.translatePath(os.path.join(profile_dir, 'settings.xml'))
+        with open(fname, 'r') as f:
+            tree = ElementTree(file=f)
+        root = tree.getroot()
+        removed = 0
+        for elem in root.findall('setting'):
+            s_id = elem.attrib.get('id')
+            if s_id in setting_ids:
+                root.remove(elem)
+                removed += 1
+                logger.info("Setting '%s' removed from '%s'", s_id, fname)
+        if removed:
+            tree.write(fname, xml_declaration=False)
+        return removed == len(setting_ids)
+    except Exception:
+        logger.error("Error removing settings '%s' from '%s':", setting_ids, fname, exc_info=True)
+    return False

--- a/plugin.video.viwx/resources/lib/itv.py
+++ b/plugin.video.viwx/resources/lib/itv.py
@@ -55,7 +55,7 @@ def get_live_schedule(hours=4, local_tz=None):
     return schedule
 
 
-def get_live_urls(url=None, title=None, start_time=None, play_from_start=False, full_hd=False):
+def get_live_urls(url=None, title=None, start_time=None, full_hd=False):
     """Return the urls to the dash stream, key service and subtitles for a particular live channel.
 
     .. note::
@@ -72,12 +72,12 @@ def get_live_urls(url=None, title=None, start_time=None, play_from_start=False, 
     start_again_url = video_locations.get('StartAgainUrl')
 
     if start_again_url:
-        if start_time and (play_from_start or kodi_utils.ask_play_from_start(title)):
+        if start_time:
             dash_url = start_again_url.format(START_TIME=start_time)
             logger.debug('get_live_urls - selected play from start at %s', start_time)
         else:
             # Go 1 hour back to ensure we get the timeshift stream with adverts embedded
-            # and can skip back a bit in the stream. Some FAST channels that do have a large
+            # and can skip back a bit in the stream. Some FAST channels that do not have a large
             # enough buffer automatically use the maximum available time shift for that channel.
             start_time = datetime.now(timezone.utc) - timedelta(seconds=3600)
             dash_url = start_again_url.format(START_TIME=start_time.strftime('%Y-%m-%dT%H:%M:%S'))

--- a/plugin.video.viwx/resources/lib/kodi_utils.py
+++ b/plugin.video.viwx/resources/lib/kodi_utils.py
@@ -99,17 +99,6 @@ def ask_log_handler(default):
         return result, ''
 
 
-def ask_play_from_start(title=None):
-    if not isinstance(title, (type(None), str)):
-        logger.error("Invalid argument passed to ask_lay_from_start: '%s'", title)
-        raise ValueError('Parameter title must be of type string')
-
-    dlg = xbmcgui.Dialog()
-    return dlg.yesno(
-            title or addon_info.name,
-            Script.localize(TXT_PLAY_FROM_START))
-
-
 def msg_dlg(msg, title=None, **kwargs):
     if not isinstance(msg, (str, int)) or not isinstance(title, (type(None), str, int)):
         logger.error("Invalid argument passed to message dialog: '%s', '%s'", msg, title)

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -289,7 +289,6 @@ def sub_menu_live(_):
                 'channel': chan_name,
                 'url': item['streamUrl'],
                 'title': prog_title,
-                'start_time': program_start_time
                 }
 
         # noinspection SpellCheckingInspection
@@ -527,7 +526,7 @@ def create_mp4_file_item(name, file_url):
 
 
 @Resolver.register
-def play_stream_live(addon, channel, url=None, title=None, start_time=None, play_from_start=False):
+def play_stream_live(addon, channel, url=None, title=None, start_time=None):
     if url is None:
         url = 'https://simulcast.itv.com/playlist/itvonline/' + channel
         logger.info("Created live url from channel name: '%s'", url)
@@ -539,13 +538,10 @@ def play_stream_live(addon, channel, url=None, title=None, start_time=None, play
         # Only affects freeview streams, is currently ignored by web.
         url = url + '?region=' + tv_region
 
-    if addon.setting['live_play_from_start'] != 'true' and not play_from_start:
-        start_time = None
     fhd_enabled = addon.setting['FHD_enabled'] == 'true'
     manifest_url, key_service_url, subtitle_url = itv.get_live_urls(url,
                                                                     title,
                                                                     start_time,
-                                                                    play_from_start,
                                                                     fhd_enabled)
     list_item = create_dash_stream_item(channel, manifest_url, key_service_url)
     if list_item:

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -47,6 +47,11 @@ TXT_ADD_TO_MYLIST = 30801
 TXT_REMOVE_FROM_MYLIST = 30802
 
 
+if Script.setting['live_play_from_start']:
+    from resources.lib.cleanup import remove_setting_value
+    remove_setting_value(utils.addon_info.profile, 'live_play_from_start')
+
+
 def empty_folder():
     kodi_utils.msg_dlg(Script.localize(TXT_NO_ITEMS_FOUND))
     # Script.notify('ITV hub', Script.localize(TXT_NO_ITEMS_FOUND), icon=Script.NOTIFY_INFO, display_time=6000)

--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -82,7 +82,7 @@ def ctx_mnu_watch_from_start(chan_id, start_time):
         'PlayMedia(plugin://', utils.addon_info.id,
         '/resources/lib/main/play_stream_live/?channel=', chan_id,
         '&start_time=', start_time[:19],
-        '&play_from_start=True, noresume)'))
+        ', noresume)'))
     return utils.addon_info.localise(TXT_PLAY_FROM_START), cmd
 
 

--- a/plugin.video.viwx/resources/settings.xml
+++ b/plugin.video.viwx/resources/settings.xml
@@ -60,11 +60,6 @@
 				</setting>
 			</group>
 			<group id="grp_live" label="30120">
-				<setting id="live_play_from_start" label="30121" type="boolean" help="30321">
-					<level>0</level>
-					<default>false</default>
-					<control type="toggle" />
-				</setting>
 				<setting id="tv_region" label="30122" type="string" help="30322">
 					<level>0</level>
 					<default>by_account</default>

--- a/test/local/test_cleanup.py
+++ b/test/local/test_cleanup.py
@@ -1,0 +1,67 @@
+# ----------------------------------------------------------------------------------------------------------------------
+#  Copyright (c) 2025 Dimitri Kroon.
+#  This file is part of plugin.video.viwx.
+#  SPDX-License-Identifier: GPL-2.0-or-later
+#  See LICENSE.txt
+# ----------------------------------------------------------------------------------------------------------------------
+
+from test.support import fixtures
+fixtures.global_setup()
+
+from io import StringIO
+from unittest import TestCase
+from unittest.mock import MagicMock, patch, mock_open
+
+
+from resources.lib import utils
+from resources.lib import cleanup
+
+
+setUpModule = fixtures.setup_local_tests
+tearDownModule = fixtures.tear_down_local_tests
+
+
+class RemoveSettingValue(TestCase):
+    settings_xml = (
+        '<settings version="2">\n'
+        '    <setting id="current">true</setting>\n'
+        '    <setting id="old_setting" default="true">true</setting>\n'
+        '    <setting id="existing">true</setting>\n'
+        '</settings>'
+    )
+
+    def test_remove_setting(self):
+        buffer = StringIO()
+        with patch('builtins.open', mock_open(read_data=self.settings_xml)) as m_open:
+            m_open.return_value.write = buffer.write
+            result = cleanup.remove_setting_value(utils.addon_info.profile, 'old_setting')
+        self.assertIs(result, True)
+        new_xml = buffer.getvalue()
+        self.assertEqual('<settings version="2">\n'
+                         '    <setting id="current">true</setting>\n'
+                         '    <setting id="existing">true</setting>\n'
+                         '</settings>',
+                         new_xml)
+
+    def test_remove_multiple_setting(self):
+        buffer = StringIO()
+        with patch('builtins.open', mock_open(read_data=self.settings_xml)) as m_open:
+            m_open.return_value.write = buffer.write
+            result = cleanup.remove_setting_value(utils.addon_info.profile, 'old_setting', 'current')
+        self.assertIs(result, True)
+        new_xml = buffer.getvalue()
+        self.assertEqual('<settings version="2">\n'
+                         '    <setting id="existing">true</setting>\n'
+                         '</settings>',
+                         new_xml)
+
+    def test_setting_not_exists(self):
+        with patch('builtins.open', mock_open(read_data=self.settings_xml)) as m_open:
+            result = cleanup.remove_setting_value(utils.addon_info.profile, 'not_existing')
+        self.assertIs(result, False)
+        m_open.return_value.write.assert_not_called()
+
+    def test_file_not_exists(self):
+        with patch('builtins.open', side_effect=OSError):
+            result = cleanup.remove_setting_value(utils.addon_info.profile, 'old_setting')
+        self.assertIs(result, False)

--- a/test/local/test_itv.py
+++ b/test/local/test_itv.py
@@ -90,7 +90,7 @@ class GetLiveUrls(TestCase):
 
     @patch('resources.lib.itvx._request_stream_data', return_value=open_json('playlists/pl_itv1.json'))
     def test_get_live_urls_start_again(self, _):
-        mpd, key, subs = itv.get_live_urls('itv1/url', start_time='2023-05-06T17:18:32Z', play_from_start=True)
+        mpd, key, subs = itv.get_live_urls('itv1/url', start_time='2023-05-06T17:18:32Z')
         self.assertTrue(is_url(mpd))
         self.assertTrue('?t=' in mpd)
         self.assertTrue(is_url(key))
@@ -101,7 +101,7 @@ class GetLiveUrls(TestCase):
         for item in playlist['Playlist']['Video']['VideoLocations']:
             del item['StartAgainUrl']
         with patch('resources.lib.itvx._request_stream_data', return_value=playlist):
-            mpd, key, subs = itv.get_live_urls('itv1/url', start_time='2023-05-06T17:18:32Z', play_from_start=True)
+            mpd, key, subs = itv.get_live_urls('itv1/url', start_time='2023-05-06T17:18:32Z')
         self.assertTrue(is_url(mpd))
         self.assertFalse('?t=' in mpd)
         self.assertTrue(is_url(key))

--- a/test/local/test_kodi_utils.py
+++ b/test/local/test_kodi_utils.py
@@ -51,11 +51,6 @@ class TestKodiUtils(unittest.TestCase):
             self.assertEqual(5, result)
             self.assertEqual('', name)
 
-    def test_ask_play_from_start(self):
-        kodi_utils.ask_play_from_start()
-        kodi_utils.ask_play_from_start('Title')
-        self.assertRaises(ValueError, kodi_utils.ask_play_from_start, 1235)
-
     def test_get_system_setting(self):
         with patch("xbmc.executeJSONRPC",
                    return_value='{"id": 1, "jsonrpc": "2.0", "result": {"value": "Europe/Amsterdam"}}') as p_rpc:

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -480,7 +480,7 @@ class PlayStreamLive(TestCase):
         self.assertTrue(object_checks.is_url(p_req_strm.call_args[0][0], '/FAST16'))
         # -- Watch from the start --
         result = main.play_stream_live.test(channel='ITV', url=None,
-                                            start_time="2024-11-03T18:00:30", play_from_start=True)
+                                            start_time="2024-11-03T18:00:30")
         self.assertIsInstance(result, XbmcListItem)
         self.assertTrue('inputstream.adaptive.play_timeshift_buffer' in result._props)
 

--- a/test/local/test_parsex.py
+++ b/test/local/test_parsex.py
@@ -54,7 +54,6 @@ class ParseSimulcastItem(unittest.TestCase):
             cmd = item['ctx_mnu'][0][1]
             self.assertTrue(cmd.startswith("PlayMedia(plugin://plugin.video.viwx/resources/lib/main/play_stream_live/?"))
             self.assertTrue('start_time=' in cmd)
-            self.assertTrue('play_from_start=True' in cmd)
 
     def test_simucast_hero(self):
         """Hero start and end time is in British local time in 'HH:MM'


### PR DESCRIPTION
To watch a live programme from the start, just use the context menu of the channel's list item.