### PR TITLE
[VERSION] 1.7.3 - Hotfix: Videos fail to play with the message: "Could not make the request. Your internet may be down."

### DIFF
--- a/plugin.video.viwx/addon.xml
+++ b/plugin.video.viwx/addon.xml
@@ -31,23 +31,12 @@
       <fanart>resources/fanart.png</fanart>
     </assets>
     <news>
-[B]v1.7.2[/B]
-[B]Fixes:[/B]
-- In some cases, Kodi continued to run the previous version for a while after the add-on was updated.
-- Short news clips fail to play in category News.
-- Support live items without start and end time.
-
-[B]v 1.7.1[/B]
-[B]Fixes:[/B]
-- Short sport clips fail to play with error 'Not Found'
-
-[B]v 1.7.0[/B]
-[B]New Features:[/B]
-- Optional full HD streams - must be enabled in settings, off by default.
-
-[B]Fixes:[/B]
-- Search with live items in the results failed.
-- Some episode listings failed.
+[B]v 1.7.3[/B]
+[B]Hotfix:[/B]
+- Videos fail to play with the message: "Could not make the request. Your internet may be down."
+[B]Note:[/B]
+This hotfix disables automatic checks and updates of the Widevine decrypter binaries.
+Visit the viwX support thread on the Kodi forum for more info.
     </news>
     <reuselanguageinvoker>true</reuselanguageinvoker>
   </extension>

--- a/plugin.video.viwx/changelog.txt
+++ b/plugin.video.viwx/changelog.txt
@@ -1,3 +1,7 @@
+v 1.7.3
+Hotfix:
+- Videos fail to play with the message: "Could not make the request. Your internet may be down."
+
 v 1.7.2
 Fixes:
 - In some cases, Kodi continued to run the previous version for a while after the add-on was updated.

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -471,8 +471,8 @@ def create_dash_stream_item(name: str, manifest_url, key_service_url, resume_tim
     DRM = 'com.widevine.alpha'
 
     is_helper = inputstreamhelper.Helper(PROTOCOL, drm=DRM)
-    if not is_helper.check_inputstream():
-        return False
+    # if not is_helper.check_inputstream():
+    #     return False
 
     play_item = ListItem(offscreen=True)
     if name:


### PR DESCRIPTION
Caused by a failed Widevine version check of the inputstreamhelper add-on.
This hotfix disables this check. As a consequence you won't get notifications when a new version of Widevine is available.

Unfortunately, it looks like the inputstreamhelper add-on in the official Kodi repro is no longer being maintained. To ensure the widevine binaries on your system are up to date, consider installing inputstreamhelper from the slyguy repo and revert back to viwx 1.7.2. https://www.matthuisman.nz/2023/12/inputstream-helper-slyguy-wrapper-add-on.html
