### PR TITLE
Removed title from the callback urls of playables

### DIFF
--- a/plugin.video.viwx/resources/lib/cc_patch.py
+++ b/plugin.video.viwx/resources/lib/cc_patch.py
@@ -78,7 +78,7 @@ def patch_label_prop():
         """Set label and only copy to fields that do not already have a value"""
         self.listitem.setLabel(label)
         unformatted_label = strip_formatting("", label)
-        self.params.setdefault("_title_", unformatted_label)
+        # self.params.setdefault("_title_", unformatted_label)
         self.info.setdefault("title", unformatted_label)
 
     Listitem.label = Listitem.label.setter(label_setter)  # type: ignore

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -465,7 +465,7 @@ def do_search(addon, search_query):
         yield li
 
 
-def create_dash_stream_item(name: str, manifest_url, key_service_url, resume_time=None):
+def create_dash_stream_item(manifest_url, key_service_url, resume_time=None):
     # noinspection PyImport,PyUnresolvedReferences
     import inputstreamhelper
 
@@ -480,9 +480,6 @@ def create_dash_stream_item(name: str, manifest_url, key_service_url, resume_tim
         return False
 
     play_item = ListItem(offscreen=True)
-    if name:
-        play_item.setLabel(name)
-        play_item.setInfo('video', {'title': name})
 
     play_item.setPath(manifest_url)
     play_item.setContentLookup(False)
@@ -519,12 +516,9 @@ def create_dash_stream_item(name: str, manifest_url, key_service_url, resume_tim
     return play_item
 
 
-def create_mp4_file_item(name, file_url):
+def create_mp4_file_item(file_url):
     logger.debug('mp4 file url: %s', file_url)
     play_item = ListItem(offscreen=True)
-    if name:
-        play_item.setLabel(name)
-        play_item.setInfo('video', {'title': name})
     play_item.setPath(file_url)
     play_item.setContentLookup(False)
     play_item.setMimeType('video/mp4')
@@ -549,7 +543,7 @@ def play_stream_live(addon, channel, url=None, title=None, start_time=None):
                                                                     title,
                                                                     start_time,
                                                                     fhd_enabled)
-    list_item = create_dash_stream_item(channel, manifest_url, key_service_url)
+    list_item = create_dash_stream_item(manifest_url, key_service_url)
     if list_item:
         if start_time and ('?t=' in manifest_url or '&t=' in manifest_url):
             list_item.setProperty('inputstream.adaptive.play_timeshift_buffer', 'true')
@@ -560,9 +554,9 @@ def play_stream_live(addon, channel, url=None, title=None, start_time=None):
 
 
 @Resolver.register
-def play_stream_catchup(plugin, url, name, set_resume_point=False):
+def play_stream_catchup(plugin, url, set_resume_point=False):
 
-    logger.info('play catchup stream - %s  url=%s', name, url)
+    logger.info('play catchup stream url=%s', url)
     fhd_enabled = plugin.setting['FHD_enabled'] == 'true'
     try:
         manifest_url, key_service_url, subtitle_url, stream_type, production_id = itv.get_catchup_urls(url, fhd_enabled)
@@ -573,9 +567,9 @@ def play_stream_catchup(plugin, url, name, set_resume_point=False):
         return False
 
     if stream_type == 'SHORT':
-        return create_mp4_file_item(name, manifest_url)
+        return create_mp4_file_item(manifest_url)
     else:
-        list_item = create_dash_stream_item(name, manifest_url, key_service_url)
+        list_item = create_dash_stream_item(manifest_url, key_service_url)
         if not list_item:
             return False
 
@@ -599,8 +593,8 @@ def play_stream_catchup(plugin, url, name, set_resume_point=False):
 
 
 @Resolver.register
-def play_title(plugin, url, name=''):
-    """Play an episode from an url to the episode's html page.
+def play_title(plugin, url):
+    """Play an episode from a url to the episode's html page.
 
     While episodes obtained from list_productions() have direct urls to stream's
     playlist, episodes from listings obtained by parsing html pages have an url
@@ -612,7 +606,7 @@ def play_title(plugin, url, name=''):
     except AccessRestrictedError:
         kodi_utils.msg_dlg(Script.localize(TXT_PREMIUM_CONTENT))
         return False
-    return play_stream_catchup(plugin, url, name)
+    return play_stream_catchup(plugin, url)
 
 
 @Script.register

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -10,6 +10,8 @@ import typing
 import string
 import sys
 
+from functools import wraps
+
 import requests
 import xbmc
 import xbmcplugin
@@ -70,6 +72,7 @@ def dynamic_listing(func=None):
     This decorator provides default behaviour for these cases.
 
     """
+    @wraps(func)
     def wrapper(*args, **kwargs):
         # Codequick will always pass a Router object as 1st positional argument and all other parameters
         # as keyword arguments, but others, like tests, may use position arguments.
@@ -88,11 +91,8 @@ def dynamic_listing(func=None):
             else:
                 # Anything that evaluates to False is 'no items found'.
                 return empty_folder()
-    if func is None:
-        return wrapper()
-    else:
-        wrapper.__name__ = 'wrapper.' + func.__name__
-        return wrapper
+
+    return wrapper
 
 
 class Paginator:

--- a/plugin.video.viwx/resources/lib/parsex.py
+++ b/plugin.video.viwx/resources/lib/parsex.py
@@ -212,8 +212,8 @@ def parse_hero_content(hero_data):
                                 duration=utils.duration_2_seconds(hero_data.get('duration')))
             item['params'] = {'url': build_url(title,
                                                hero_data['encodedProgrammeId']['letterA'],
-                                               hero_data.get('encodedEpisodeId', {}).get('letterA')),
-                              'name': title}
+                                               hero_data.get('encodedEpisodeId', {}).get('letterA'))
+                              }
             if item_type == 'episode':
                 context_mnu.append(ctx_mnu_all_episodes(hero_data['encodedProgrammeId']['letterA']))
 
@@ -594,7 +594,7 @@ def parse_episode_title(title_data, brand_fanart=None, prefer_bsl=False):
                  'episode': episode_nr,
                  'season': series_nr,
                  'year': title_data.get('productionYear')},
-        'params': {'url': playlist_url, 'name': title}
+        'params': {'url': playlist_url}
     }
 
     return title_obj
@@ -755,7 +755,6 @@ def parse_last_watched_item(item, utc_now):
                      'episode': episode_nr},
             'params': {'url': ('https://magni.itv.com/playlist/itvonline/ITV/' +
                                item['productionId'].replace('/', '_').replace('#', '.')),
-                       'name': progr_name,
                        'set_resume_point': True},
             'properties': {
                 # This causes Kodi not to offer the standard resume dialog, so we can obtain

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -4,12 +4,14 @@
 #  SPDX-License-Identifier: GPL-2.0-or-later
 #  See LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt
 # ----------------------------------------------------------------------------------------------------------------------
-import xbmcaddon
+from __future__ import annotations
 
 from test.support import fixtures
 fixtures.global_setup()
 
 import json
+import importlib
+import inspect
 
 from datetime import datetime, timezone
 from unittest import TestCase
@@ -30,6 +32,34 @@ from resources.lib import itv_account
 
 setUpModule = fixtures.setup_local_tests
 tearDownModule = fixtures.tear_down_local_tests
+
+
+def check_list_items(testcase: TestCase, list_items: Listitem | list[Listitem]):
+    """Perform some checks on codequick Listitems
+
+    """
+    if isinstance(list_items, Listitem):
+        list_items = [list_items]
+    for li in list_items:
+        testcase.assertIsInstance(li, Listitem)
+        # Ascertain it builds
+        li.build()
+        # Check that the callback arguments are present in the callback function.
+        path_parts = li.path.path.strip('/').split('/')
+        module = importlib.import_module('.'.join(path_parts[:-1]))
+        callb = getattr(module, path_parts[-1])
+        callb_sign = inspect.signature(callb)
+        if any(param.kind == param.VAR_KEYWORD for param in callb_sign.parameters.values()):
+            # all keyword arguments are accepted.
+            continue
+        for kwarg in li.params.keys():
+            if kwarg.startswith('_') and kwarg.endswith('_'):
+                # Special keyword arguments used internally by codequick.
+                # To keep playable urls consistent, do not allow these in playable items.
+                testcase.assertFalse(li.path.is_playable)
+                continue
+            testcase.assertTrue(kwarg in callb_sign.parameters,
+                                f"Keyword argument '{kwarg}' not present in callback '{path_parts[-1]}'.")
 
 
 class Paginator(TestCase):
@@ -57,14 +87,16 @@ class MainMenu(TestCase):
         mockeddt.mocked_now = datetime.now(tz=timezone.utc).replace(hour=21)
         items = list(main.root.test())
         self.assertGreater(len(items), 10)
+        # Check context before listitem check, because Listitem.build()
+        # will create context menus on every playable.
         items_with_ctx_menus = 0
         for item in items:
-            self.assertIsInstance(item, Listitem)
             if len(item.context) > 0:
                 items_with_ctx_menus += 1
         # Check 'My ItvX' is present
         self.assertTrue(items[0].label == 'My itvX')
         self.assertEqual(6, items_with_ctx_menus)
+        check_list_items(self, items)
 
 
 class LiveChannels(TestCase):
@@ -77,6 +109,7 @@ class LiveChannels(TestCase):
         self.assertIsInstance(chans, list)
         chan_list = list(chans)
         self.assertGreaterEqual(len(chan_list), 10)
+        check_list_items(self, chan_list)
         self.assertEqual(2, mocked_get_json.call_count)
         # Next call is from cache
         main.sub_menu_live.test()
@@ -89,6 +122,7 @@ class LiveChannels(TestCase):
         cache.purge()
         chans = main.sub_menu_live.test()
         self.assertIsInstance(chans, list)
+        self.assertGreaterEqual(len(chans), 10)
 
 
 class MyItvx(TestCase):
@@ -103,6 +137,7 @@ class MyItvx(TestCase):
             with patch('resources.lib.fetch.get_json', return_value=open_json('usercontent/byw.json')):
                 list_items = main.sub_menu_my_itvx.test()
                 self.assertEqual(4, len(list_items))
+                check_list_items(self, list_items)
 
     @patch('resources.lib.itv_account.fetch_authenticated',
            new=lambda funct, url, login=True, **kwargs: funct(url, **kwargs))
@@ -112,6 +147,7 @@ class MyItvx(TestCase):
                    return_value=HttpResponse(text=open_doc('usercontent/last_watched_all.json')())) as p_fetch:
             shows = list(main.generic_list.test('watching', filter_char=None))
             self.assertEqual(10, len(shows))
+            check_list_items(self, shows)
             p_fetch.assert_called_once()
         # All responses below have been observed in the wild when the watched list had no items.
         cache.purge()
@@ -135,8 +171,7 @@ class MyItvx(TestCase):
     def test_list_mylist(self, _):
         li_items = main.generic_list.test(filter_char=None, page_nr=None)
         self.assertIsInstance(li_items, list)
-        for item in li_items:
-            self.assertIsInstance(item, Listitem)
+        check_list_items(self, li_items)
 
     @patch('resources.lib.cache.my_list_programmes', new=None)
     def test_my_list_context_menu_not_logged_in(self):
@@ -191,6 +226,7 @@ class MyItvx(TestCase):
             result = main.generic_list.test('byw')
         p_fetch.assert_called_once()
         self.assertEqual(12, len(result))
+        check_list_items(self, result)
 
     @patch('resources.lib.fetch.get_json', return_value=open_json('usercontent/recommended.json'))
     def test_recommended(self, p_fetch):
@@ -200,6 +236,7 @@ class MyItvx(TestCase):
             result = main.generic_list.test('recommended')
         p_fetch.assert_called_once()
         self.assertEqual(12, len(result))
+        check_list_items(self, result)
 
         # Logged In
         p_fetch.reset_mock()
@@ -208,11 +245,13 @@ class MyItvx(TestCase):
             result = main.generic_list.test('recommended')
             p_fetch.assert_called_once()
             self.assertEqual(12, len(result))
+            check_list_items(self, result)
 
             # Hide paid
             with patch('xbmcaddon.Addon.getSetting', return_value='true'):
                 result = main.generic_list.test('recommended')
             self.assertEqual(11, len(result))       # one paid item in the list.
+            check_list_items(self, result)
 
     def test_non_existing_type_of_generic_list(self):
         self.assertRaises(ValueError, main.generic_list.test, 'non-existing-list')
@@ -223,34 +262,31 @@ class Collections(TestCase):
     def test_get_collections(self, _):
         coll = main.list_collections.test()
         self.assertEqual(17, len(coll))
+        check_list_items(self, coll)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('json/index-data.json'))
     def test_get_collection_news(self, _):
         shows = list(filter(None, main.list_collection_content.test(slider='newsShortForm')))
         self.assertEqual(len(shows), 3)
-        for item in shows:
-            self.assertIsInstance(item, Listitem)
+        check_list_items(self, shows)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('json/index-data.json'))
     def test_get_collection_trending(self, _):
         shows = list(filter(None, main.list_collection_content.test(slider='trendingSliderContent')))
         self.assertGreater(len(shows), 10)
-        for item in shows:
-            self.assertIsInstance(item, Listitem)
+        check_list_items(self, shows)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/collection_just-in_data.json'))
     def test_get_collection_from_collection_page(self, _):
         shows = list(filter(None, main.list_collection_content.test(url='top-picks')))
         self.assertGreater(len(shows), 10)
-        for item in shows:
-            self.assertIsInstance(item, Listitem)
+        check_list_items(self, shows)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/collection_itvx-kids.json'))
     def test_get_collection_from_collection_page_with_rails(self, _):
         shows = list(filter(None, main.list_collection_content.test(url='itvs-kids')))
         self.assertGreater(len(shows), 10)
-        for item in shows:
-            self.assertIsInstance(item, Listitem)
+        check_list_items(self, shows)
 
 
 class Categories(TestCase):
@@ -261,21 +297,20 @@ class Categories(TestCase):
     def test_get_categories(self, _):
         cats = main.list_categories.test()
         self.assertAlmostEqual(len(cats), 8, delta=2)
-        for cat in cats:
-            self.assertIsInstance(cat, Listitem)
+        check_list_items(self, cats)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_drama-soaps.json'))
     def test_get_category_drama(self, _):
         programmes = main.list_category.test('sdfg')
         self.assertGreater(len(programmes), 100)
-        for prog in programmes:
-            self.assertIsInstance(prog, (Listitem, type(None)))
+        check_list_items(self, programmes)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_films.json'))
     def test_category_film(self, _):
         items = main.list_category.test('category/films')
         self.assertIsInstance(items, list)
         self.assertEqual(292, len(items))
+        check_list_items(self, items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_children.json'))
     def test_get_category_children_paginated(self, _):
@@ -283,18 +318,22 @@ class Categories(TestCase):
         with patch('xbmcaddon.Addon.getSettingInt', side_effect=(0, 60) * 2):  # no a-z, page length = 30
             programmes = list(filter(None, main.list_category.test('sdfg')))
             self.assertEqual(61, len(programmes))
+            check_list_items(self, programmes)
             programmes = list(filter(None, main.list_category.test('sdfg', page_nr=2)))
             self.assertEqual(8, len(programmes))
+            check_list_items(self, programmes)
         with patch('xbmcaddon.Addon.getSettingInt', side_effect=(0, 125)):  # no a-z, page length = 55
             # content must be more than 5 longer than page length before actual pagination is performed.
             programmes = list(filter(None, main.list_category.test('sdfg')))
             self.assertEqual(128, len(programmes))
+            check_list_items(self, programmes)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_children.json'))
     def test_category_children_az_list(self, _):
         with patch('xbmcaddon.Addon.getSettingInt', side_effect=(20, 0)):  # a-z on 20 items, page length=0
             programmes = list(filter(None, main.list_category.test('sdfg')))
             self.assertEqual(20, len(programmes))
+            check_list_items(self, programmes)
             self.assertEqual('A', programmes[0].label)
             self.assertEqual('A', programmes[0].params['filter_char'])
 
@@ -303,15 +342,19 @@ class Categories(TestCase):
         with patch('xbmcaddon.Addon.getSettingInt', side_effect=(20, 0) * 2):  # a-z on 20 items, page length=0
             programmes = list(filter(None, main.list_category.test('sdfg', filter_char='A')))
             self.assertEqual(19, len(programmes))
+            check_list_items(self, programmes)
             programmes = list(filter(None, main.list_category.test('sdfg', filter_char='0-9')))
             self.assertEqual(1, len(programmes))
+            check_list_items(self, programmes)
         # Test content of 'A' divided in sub-pages
         with patch('xbmcaddon.Addon.getSettingInt', side_effect=(20, 6)*3):  # a-z on 20 items, page length=6
             programmes = list(filter(None, main.list_category.test('sdfg', filter_char='A')))
             self.assertEqual(7, len(programmes))
+            check_list_items(self, programmes)
             programmes = list(filter(None, main.list_category.test('sdfg', filter_char='A', page_nr=2)))
             # Categories 'A' has 19 items
             self.assertEqual(7, len(programmes))  # The remaining item of the last page is added to this one.
+            check_list_items(self, programmes)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_news.json'))
     def test_category_news(self, _):
@@ -319,12 +362,14 @@ class Categories(TestCase):
         items = main.list_category.test('category/news')
         self.assertIsInstance(items, list)
         self.assertEqual(7, len(items))
+        check_list_items(self, items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_news.json'))
     def test_sub_category_news_hero_items(self, _):
         items = main.list_news_sub_category.test('my/url', 'heroAndLatestData', None)
         self.assertIsInstance(items, list)
         self.assertEqual(12, len(items))
+        check_list_items(self, items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_news.json'))
     def test_sub_category_news_long_format_items(self, _):
@@ -332,6 +377,7 @@ class Categories(TestCase):
         items = main.list_news_sub_category.test('my/url', 'longformData', None)
         self.assertIsInstance(items, list)
         self.assertEqual(36, len(items))
+        check_list_items(self, items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/category_news.json'))
     def test_sub_category_news_rails(self, _):
@@ -339,6 +385,7 @@ class Categories(TestCase):
         items = main.list_news_sub_category.test('my/url', 'curatedRails', 'All Around The UK')
         self.assertIsInstance(items, list)
         self.assertEqual(12, len(items))
+        check_list_items(self, items)
 
 
 @patch("resources.lib.cache.get_item", new=lambda *a, **k: None)     # disable cache
@@ -357,6 +404,7 @@ class Productions(TestCase):
         list_items = main.list_productions.test('some/url/to/marple')
         self.assertIsInstance(list_items, list)
         self.assertEqual(6, len(list_items))
+        check_list_items(self, list_items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/series_miss-marple_data.json'))
     def test_episodes_marple_series_4(self, _):
@@ -364,6 +412,7 @@ class Productions(TestCase):
         list_items = main.list_productions.test('some/url/to/marple', series_idx='4')
         self.assertIsInstance(list_items, list)
         self.assertEqual(4, len(list_items))
+        check_list_items(self, list_items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/series_midsomer-murders.json'))
     def test_episodes_midsummer_murders_series_other_episodes(self, _):
@@ -371,6 +420,7 @@ class Productions(TestCase):
         list_items = main.list_productions.test('/some/url//to/midsumer', series_idx='others')
         self.assertIsInstance(list_items, list)
         self.assertEqual(1, len(list_items))      # 22 series, 1 episode
+        check_list_items(self, list_items)
 
     @patch('resources.lib.itvx.get_page_data', return_value=open_json('html/series_bad-girls_data.json'))
     def test_episodes_bad_girls_series_5(self, _):
@@ -378,6 +428,7 @@ class Productions(TestCase):
         list_items = main.list_productions.test('some/url/to/bad girls', series_idx='5')
         self.assertIsInstance(list_items, list)
         self.assertEqual(16, len(list_items))
+        check_list_items(self, list_items)
 
     def test_episode_of_show_with_only_one_series(self):
         # FIXME: Not quite sure what we are actually testing here.
@@ -389,6 +440,7 @@ class Productions(TestCase):
         with patch('resources.lib.itvx.get_page_data', return_value=data):
             series_listing = main.list_productions.test('asd')
             self.assertEqual(4, len(series_listing))
+            check_list_items(self, series_listing)
             # Check if all items are playable
             for episode in series_listing:
                 self.assertIs(episode.path, main.play_stream_catchup.route)
@@ -398,6 +450,7 @@ class Productions(TestCase):
         list_items = main.list_productions.test('some/url/to/mids murders', series_idx='others')
         self.assertIsInstance(list_items, list)
         self.assertEqual(1, len(list_items))
+        check_list_items(self, list_items)
 
 
 class Search(TestCase):
@@ -409,6 +462,7 @@ class Search(TestCase):
         self.assertEqual(8, len(results))
         self.assertIs(results[0].path, main.list_productions.route)  # programme
         self.assertIs(results[4].path, main.play_title.route)  # film
+        check_list_items(self, results)
 
     @patch('requests.sessions.Session.send',
            return_value=HttpResponse(text=open_doc('search/test_results.json')()))
@@ -418,17 +472,21 @@ class Search(TestCase):
         with patch('xbmcaddon.Addon.getSetting', return_value='true'):
             results = main.do_search.test('__')
             self.assertEqual(5, len(results))
+        check_list_items(self, results)
 
     def test_search_result_with_unknown_entitytype(self):
         search_data = open_json('search/test_results.json')
         with patch('requests.sessions.Session.send', return_value=HttpResponse(text=json.dumps(search_data))):
             results_1 = main.do_search.test('kjhbn')
             self.assertEqual(8, len(results_1))
+            check_list_items(self, results_1)
+
         # check again with one item having an unknown entity type
         search_data['results'][3]['entityType'] = 'video'
         with patch('requests.sessions.Session.send', return_value=HttpResponse(text=json.dumps(search_data))):
             results_2 = main.do_search.test('kjhbn')
             self.assertEqual(7, len(results_2))
+            check_list_items(self, results_2)
 
     @patch('requests.sessions.Session.send', return_value=HttpResponse(204))
     def test_search_with_no_results(self, _):

--- a/test/support/fixtures.py
+++ b/test/support/fixtures.py
@@ -61,6 +61,10 @@ def global_setup():
         # Use an xbmcgui.ListItem that stores the values which have been set.
         patch_listitem()
 
+        # Apply codequick patches
+        from resources.lib.cc_patch import patch_label_prop
+        patch_label_prop()
+
 
 patch_1 = None
 

--- a/test/support/fixtures.py
+++ b/test/support/fixtures.py
@@ -2,7 +2,7 @@
 #  Copyright (c) 2022-2025 Dimitri Kroon.
 #  This file is part of plugin.video.viwx.
 #  SPDX-License-Identifier: GPL-2.0-or-later
-#  See LICENSE.txt
+#  See LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt
 # ----------------------------------------------------------------------------------------------------------------------
 
 import os
@@ -236,17 +236,20 @@ def localise_mock(self, str_id):
     Returns only the text of the first line in the file.
 
     """
-    pattern = f'msgctxt "#{str_id}"\nmsgid "([^"]*)"'
-    test_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '../'))
-    lang_file = os.path.join(
-        test_dir,
-        '../plugin.video.viwx/resources/language/resource.language.en_gb/strings.po')
-    with open(lang_file) as f:
-        lang_texts = f.read()
-    match = re.search(pattern, lang_texts)
-    if match:
-        return match[1]
-    return ''
+    if 30000 <= str_id <= 30999:
+        pattern = f'msgctxt "#{str_id}"\nmsgid "([^"]*)"'
+        test_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '../'))
+        lang_file = os.path.join(
+            test_dir,
+            '../plugin.video.viwx/resources/language/resource.language.en_gb/strings.po')
+        with open(lang_file) as f:
+            lang_texts = f.read()
+        match = re.search(pattern, lang_texts)
+        if match:
+            return match[1]
+        return ''
+    else:
+        return 'UNKNOWN_SYS_STRING'
 
 
 class FileMock(xbmcvfs.File):
@@ -257,7 +260,7 @@ class FileMock(xbmcvfs.File):
         self._file = open(translate_path_mock(filepath), mode)
 
     def read(self, numBytes: int = 0) -> str:
-        # For some reason Kodi's default numBytes == 0, while python requires -1 to read all content.
+        # For some reason Kodi's default numBytes == 0, while Python requires -1 to read all content.
         if numBytes == 0:
             numBytes = -1
         return self._file.read(numBytes)

--- a/test/web/test_main.py
+++ b/test/web/test_main.py
@@ -2,7 +2,7 @@
 #  Copyright (c) 2022-2025 Dimitri Kroon.
 #  This file is part of plugin.video.viwx.
 #  SPDX-License-Identifier: GPL-2.0-or-later
-#  See LICENSE.txt
+#  See LICENSE.txt or https://www.gnu.org/licenses/gpl-2.0.txt
 # ----------------------------------------------------------------------------------------------------------------------
 from test.support import fixtures
 fixtures.global_setup()
@@ -151,31 +151,24 @@ class TestGetProductions(unittest.TestCase):
 class TestPlayCatchup(unittest.TestCase):
     def test_play_itv_1(self):
         result = main.play_stream_live.test("itv", 'https://simulcast.itv.com/playlist/itvonline/itv', None)
-        self.assertEqual('itv', result.getLabel())
         self.assertIsInstance(result, XbmcListItem)
 
     def test_play_vod_a_touch_of_frost(self):
         result = main.play_stream_catchup(MagicMock(),
-                                          url='https://magni.itv.com/playlist/itvonline/ITV3/Y_1774_0002_Y',
-                                          name='A Touch of Frost')
-        self.assertEqual('A Touch of Frost', result.getLabel())
+                                          url='https://magni.itv.com/playlist/itvonline/ITV3/Y_1774_0002_Y' )
         self.assertRaises(AttributeError, getattr, result, '_subtitles')
         self.assertIsInstance(result, XbmcListItem)
 
     def test_play_vod_frost_with_subtitles(self):
         with patch.object(itv.Script, 'setting', new={'subtitles_show': 'true', 'subtitles_color': 'true'}):
             result = main.play_stream_catchup(MagicMock(),
-                                              url='https://magni.itv.com/playlist/itvonline/ITV3/Y_1774_0002_Y',
-                                              name='A Touch of Frost')
-        self.assertEqual('A Touch of Frost', result.getLabel())
+                                              url='https://magni.itv.com/playlist/itvonline/ITV3/Y_1774_0002_Y')
         self.assertEqual(1, len(result._subtitles))
         self.assertIsInstance(result, XbmcListItem)
 
     def test_play_vod_episode_julia_bradbury(self):
         result = main.play_stream_catchup(MagicMock(),
-                                          url='https://magni.itv.com/playlist/itvonline/ITV/10_0852_0001.001',
-                                          name='Walks with Julia Bradbury')
-        self.assertEqual('Walks with Julia Bradbury', result.getLabel())
+                                          url='https://magni.itv.com/playlist/itvonline/ITV/10_0852_0001.001')
         self.assertIsInstance(result, XbmcListItem)
         self.assertTrue(object_checks.is_url(result.getPath(), '.mpd'))
 
@@ -185,7 +178,7 @@ class TestPlayCatchup(unittest.TestCase):
         news_item = page_data['shortFormSliderContent'][0]['items'][0]
         item_url = '/'.join(('https://www.itv.com/watch/news', news_item['titleSlug'], news_item['episodeId']))
         # play the item
-        result = main.play_title.test(item_url, 'news item')
+        result = main.play_title.test(item_url)
         self.assertIsInstance(result, XbmcListItem)
         self.assertTrue(object_checks.is_url(result.getPath(), '.mp4'))
 


### PR DESCRIPTION
To remember play status, Kodi identifies playables by their callback url. This PR ensures that the play state of programme stays the same when the title of the programme changes, either by ITVX, or by changes in the addon.