### PR TITLE
Enable audio description channel when available.

### DIFF
--- a/plugin.video.viwx/resources/lib/itv.py
+++ b/plugin.video.viwx/resources/lib/itv.py
@@ -86,13 +86,13 @@ def get_live_urls(url=None, title=None, start_time=None, full_hd=False):
     return dash_url, key_service, None
 
 
-def get_catchup_urls(playlist_url, full_hd=False):
+def get_catchup_urls(playlist_url, full_hd=False, has_ad=False):
     """Return the urls to the dash stream, key service and subtitles for a particular catchup
     episode and the type of video.
 
     """
     from resources.lib import itvx
-    playlist = itvx._request_stream_data(playlist_url, 'catchup', full_hd)['Playlist']
+    playlist = itvx._request_stream_data(playlist_url, 'catchup', full_hd, has_ad)['Playlist']
     stream_data = playlist['Video']
 
     # Select the media with the highest resolution

--- a/plugin.video.viwx/resources/lib/itv_gql.py
+++ b/plugin.video.viwx/resources/lib/itv_gql.py
@@ -74,9 +74,10 @@ def get_playlist_url(ccid: str, prefer_bsl: bool = False):
     version = titles[0]['latestAvailableVersion']
     bsl = version['bsl']
     if prefer_bsl and bsl:
-        return bsl.get('playlistUrl') or version['playlistUrl']
+        playlist = bsl.get('playlistUrl') or version['playlistUrl']
     else:
-        return version['playlistUrl']
+        playlist = version['playlistUrl']
+    return playlist, version['audioDescribed']
 
 
 def get_short_playlist_url(ccid: str, is_sport: bool = False):

--- a/plugin.video.viwx/resources/lib/itvx.py
+++ b/plugin.video.viwx/resources/lib/itvx.py
@@ -667,7 +667,7 @@ features_live = {
 features_catchup = ['mpeg-dash', 'widevine', 'outband-webvtt', 'hd', 'single-track']
 
 
-def _request_stream_data(url, stream_type='live', full_hd=False):
+def _request_stream_data(url, stream_type='live', full_hd=False, has_ad=False):
     from .itv_account import itv_session, fetch_authenticated
     session = itv_session()
 
@@ -683,7 +683,12 @@ def _request_stream_data(url, stream_type='live', full_hd=False):
         stream_req_data['variantAvailability']['featureset'] = features_live
     else:
         accept_type = 'application/vnd.itv.vod.playlist.v4+json'
-        stream_req_data['variantAvailability']['featureset'] = features_catchup
+        if has_ad:
+            features = features_catchup[:]
+            features.append('inband-audio-description')
+        else:
+            features = features_catchup
+        stream_req_data['variantAvailability']['featureset'] = features
 
     stream_data = fetch_authenticated(
         fetch.post_json, url,

--- a/plugin.video.viwx/resources/lib/main.py
+++ b/plugin.video.viwx/resources/lib/main.py
@@ -558,8 +558,8 @@ def play_stream_catchup(plugin, ccid, set_resume_point=False):
     from resources.lib import itv_gql
 
     logger.info('play catchup stream ccid=%s', ccid)
-    playlist_url = itv_gql.get_playlist_url(ccid=ccid, prefer_bsl=plugin.setting['prefer_bsl'] == 'true')
-    return play_vod(plugin, playlist_url, set_resume_point)
+    playlist_url, has_ad = itv_gql.get_playlist_url(ccid=ccid, prefer_bsl=plugin.setting['prefer_bsl'] == 'true')
+    return play_vod(plugin, playlist_url, set_resume_point, has_ad)
 
 
 @Resolver.register
@@ -572,11 +572,11 @@ def play_clip(plugin, ccid, is_sport):
     return play_vod(plugin, playlist_url)
 
 
-def play_vod(plugin, playlist_url, set_resume_point=False):
+def play_vod(plugin, playlist_url, set_resume_point=False, has_ad=False):
     fhd_enabled = plugin.setting['FHD_enabled'] == 'true'
     try:
         manifest_url, key_service_url, subtitle_url, stream_type, production_id = itv.get_catchup_urls(
-            playlist_url, fhd_enabled)
+            playlist_url, fhd_enabled, has_ad)
         logger.debug('dash subtitles url: %s', subtitle_url)
     except AccessRestrictedError:
         logger.info('Stream only available with premium account')

--- a/test/local/test_itv_gql.py
+++ b/test/local/test_itv_gql.py
@@ -58,9 +58,9 @@ class GqlPostQuery(TestCase):
 class VodPlayList(TestCase):
     @patch('resources.lib.fetch.get_json', return_value=open_json('gql/vod-by-ccid.json'))
     def test_get_vod_playlist_url(self, _):
-        vod_url = itv_gql.get_playlist_url('asdfg')
+        vod_url, has_ad = itv_gql.get_playlist_url('asdfg')
         self.assertTrue(is_url(vod_url))
-        bsl_url = itv_gql.get_playlist_url('asdfg', prefer_bsl=True)
+        bsl_url, has_ad = itv_gql.get_playlist_url('asdfg', prefer_bsl=True)
         self.assertTrue(is_url(bsl_url))
         self.assertNotEqual(vod_url, bsl_url)
 
@@ -77,7 +77,7 @@ class VodPlayList(TestCase):
             }
         })
         with patch('resources.lib.fetch.get_json', return_value=json_data):
-            vod_url = itv_gql.get_playlist_url('asdfg')
+            vod_url, has_ad = itv_gql.get_playlist_url('asdfg')
             self.assertTrue(is_url(vod_url))
 
 

--- a/test/local/test_main.py
+++ b/test/local/test_main.py
@@ -570,7 +570,7 @@ class PlayStreamLive(TestCase):
 
 
 # noinspection PyMethodMayBeStatic
-@patch('resources.lib.itv_gql.get_playlist_url', return_value='pl_url')
+@patch('resources.lib.itv_gql.get_playlist_url', return_value=('pl_url', True))
 @patch('resources.lib.main.play_vod')
 class PlayStreamCatchUp(TestCase):
     def test_play_stream_catchup_bsl_treu(self, p_play_vod, p_get_playlist):
@@ -578,21 +578,21 @@ class PlayStreamCatchUp(TestCase):
         plugin.setting = {'prefer_bsl': 'false'}
         main.play_stream_catchup(plugin, 'myccid', set_resume_point=False)
         p_get_playlist.assert_called_once_with(ccid='myccid', prefer_bsl=False)
-        p_play_vod.assert_called_once_with(plugin, 'pl_url', False)
+        p_play_vod.assert_called_once_with(plugin, 'pl_url', False, True)
 
     def test_play_stream_catchup_bsl_false(self, p_play_vod, p_get_playlist):
         plugin = MagicMock()
         plugin.setting = {'prefer_bsl': 'true'}
         main.play_stream_catchup(plugin, 'myccid', set_resume_point=False)
         p_get_playlist.assert_called_once_with(ccid='myccid', prefer_bsl=True)
-        p_play_vod.assert_called_once_with(plugin, 'pl_url', False)
+        p_play_vod.assert_called_once_with(plugin, 'pl_url', False, True)
 
     def test_play_stream_catchup_set_resume(self, p_play_vod, p_get_playlist):
         plugin = MagicMock()
         plugin.setting = {'prefer_bsl': 'false'}
         main.play_stream_catchup(plugin, 'myccid', set_resume_point=True)
         p_get_playlist.assert_called_once_with(ccid='myccid', prefer_bsl=False)
-        p_play_vod.assert_called_once_with(plugin, 'pl_url', True)
+        p_play_vod.assert_called_once_with(plugin, 'pl_url', True, True)
 
 
 # noinspection PyMethodMayBeStatic

--- a/test/test_docs/html/series_code-of-silence_AD.json
+++ b/test/test_docs/html/series_code-of-silence_AD.json
@@ -1,0 +1,459 @@
+{
+  "navAdServerParams": {
+    "area": "video",
+    "programmeTitle": "Code of Silence",
+    "channel": null,
+    "category": "DRAMA_AND_SOAPS",
+    "episodeId": "10_5340"
+  },
+  "forceRefresh": true,
+  "isAccessibleByKids": false,
+  "newsVideos": null,
+  "subnav": null,
+  "programme": {
+    "ccid": "1v32dzd",
+    "contentOwner": null,
+    "description": "A dangerous game of pursuit\u2014unmissable new crime drama",
+    "encodedProgrammeId": {
+      "letterA": "10a5340",
+      "underscore": "10_5340"
+    },
+    "genres": [
+      {
+        "id": "DRAMA_AND_SOAPS",
+        "name": "Drama"
+      }
+    ],
+    "heroCtaLabel": "Series 1, Episode 1",
+    "image": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+    "longDescription": "A dangerous game of pursuit\u2014unmissable new crime drama starring Rose Ayling-Ellis. A deaf waitress with vital lip-reading abilities is pulled into an elaborate investigation.",
+    "numberOfAvailableSeries": 1,
+    "partnership": null,
+    "programmeId": "10_5340",
+    "tier": [
+      "FREE"
+    ],
+    "title": "Code of Silence",
+    "titleSlug": "code-of-silence",
+    "visuallySigned": false,
+    "attribution": {
+      "partnership": null,
+      "contentOwner": null
+    },
+    "imagePresets": {
+      "0": {
+        "1x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=767&q=65&blur=0&bg=false",
+        "2x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=1074&q=65&blur=0&bg=false"
+      },
+      "768": {
+        "1x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=1279&q=80&blur=0&bg=false",
+        "2x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=1791&q=80&blur=0&bg=false"
+      },
+      "1280": {
+        "1x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=1597&q=80&blur=0&bg=false",
+        "2x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=2236&q=80&blur=0&bg=false"
+      },
+      "1920": {
+        "1x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=1597&q=80&blur=0&bg=false",
+        "2x": "https://ovp.itv.com/v2/images/programme/1v32dzd/itv_hub/01_Hero_DesktopCTV/16x9?distributionPartner=itv_hub&fallback=standard&w=2236&q=80&blur=0&bg=false"
+      }
+    }
+  },
+  "seriesList": [
+    {
+      "seriesNumber": "1",
+      "seriesLabel": "Series 1",
+      "legacyId": "10/5340-01",
+      "fullSeries": true,
+      "seriesType": "SERIES",
+      "longRunning": false,
+      "numberOfAvailableEpisodes": 6,
+      "titles": [
+        {
+          "ccid": "27dmvck",
+          "accessibilityTags": [
+            "ad",
+            "s"
+          ],
+          "audioDescribed": true,
+          "availabilityFeatures": [
+            "MPEG_DASH",
+            "OUTBAND_WEBVTT",
+            "PLAYREADY",
+            "WIDEVINE",
+            "INBAND_AUDIO_DESCRIPTION"
+          ],
+          "availabilityFrom": "2025-05-18T06:00:00Z",
+          "availabilityUntil": "2030-05-17T22:59:00Z",
+          "genres": [
+            {
+              "id": "DRAMA_AND_SOAPS",
+              "name": "Drama"
+            }
+          ],
+          "channel": "ITV",
+          "fullSeriesRange": [],
+          "heroCtaLabel": "Series 1, Episode 1",
+          "contentInfo": "S1:E1",
+          "contentOwner": null,
+          "dateTime": "2025-05-18T20:00:00.000Z",
+          "description": "A deaf catering worker is called upon by a police detective. ",
+          "duration": "1h",
+          "episode": 1,
+          "episodeId": "10/5340/0001",
+          "encodedEpisodeId": {
+            "letterA": "10a5340a0001",
+            "underscore": "10_5340_0001"
+          },
+          "episodeTitle": null,
+          "guidance": "With some strong language. Violent scenes and flashing images from the start. ",
+          "image": "https://ovp.itv.com/v2/images/episode/27dmvck/itv_hub/08_Episodic/16x9?distributionPartner=itv_hub&fallback=standard&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+          "linearContent": true,
+          "longDescription": "A deaf catering worker who is struggling to make ends meet is called upon by a police detective superintendent to lip-read the conversations of criminals.",
+          "longRunning": false,
+          "nextProductionId": "10/5340/0002",
+          "notFormattedDuration": "PT1H",
+          "partnership": null,
+          "playlistUrl": "https://magni.itv.com/playlist/itvonline/ITV/10_5340_0001.001",
+          "premium": false,
+          "productionId": "10/5340/0001#001",
+          "productionType": "EPISODE",
+          "productionYear": null,
+          "programmeId": "10/5340",
+          "series": 1,
+          "subtitled": true,
+          "tier": [
+            "FREE"
+          ],
+          "visuallySigned": false,
+          "regionalisation": true,
+          "broadcastDateTime": "2025-05-18T20:00:00Z",
+          "attribution": {
+            "partnership": null,
+            "contentOwner": null
+          }
+        },
+        {
+          "ccid": "8vjzs6m",
+          "accessibilityTags": [
+            "ad",
+            "s"
+          ],
+          "audioDescribed": true,
+          "availabilityFeatures": [
+            "MPEG_DASH",
+            "OUTBAND_WEBVTT",
+            "PLAYREADY",
+            "WIDEVINE",
+            "INBAND_AUDIO_DESCRIPTION"
+          ],
+          "availabilityFrom": "2025-05-18T06:00:00Z",
+          "availabilityUntil": "2030-05-17T22:59:00Z",
+          "genres": [
+            {
+              "id": "DRAMA_AND_SOAPS",
+              "name": "Drama"
+            }
+          ],
+          "channel": "ITV",
+          "fullSeriesRange": [],
+          "heroCtaLabel": "Series 1, Episode 2",
+          "contentInfo": "S1:E2",
+          "contentOwner": null,
+          "dateTime": "2025-05-19T20:00:00.000Z",
+          "description": " Alison's vital lipreading uncovers the gang's plans for London.",
+          "duration": "1h",
+          "episode": 2,
+          "episodeId": "10/5340/0002",
+          "encodedEpisodeId": {
+            "letterA": "10a5340a0002",
+            "underscore": "10_5340_0002"
+          },
+          "episodeTitle": null,
+          "guidance": "With some strong language and violence.",
+          "image": "https://ovp.itv.com/v2/images/episode/8vjzs6m/itv_hub/08_Episodic/16x9?distributionPartner=itv_hub&fallback=standard&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+          "linearContent": true,
+          "longDescription": "Alison's vital lipreading aids the detectives in uncovering the gang's plans, but she can only conceal her meeting with Liam from them for so long.",
+          "longRunning": false,
+          "nextProductionId": "10/5340/0003",
+          "notFormattedDuration": "PT1H",
+          "partnership": null,
+          "playlistUrl": "https://magni.itv.com/playlist/itvonline/ITV/10_5340_0002.001",
+          "premium": false,
+          "productionId": "10/5340/0002#001",
+          "productionType": "EPISODE",
+          "productionYear": null,
+          "programmeId": "10/5340",
+          "series": 1,
+          "subtitled": true,
+          "tier": [
+            "FREE"
+          ],
+          "visuallySigned": false,
+          "regionalisation": true,
+          "broadcastDateTime": "2025-05-19T20:00:00Z",
+          "attribution": {
+            "partnership": null,
+            "contentOwner": null
+          }
+        },
+        {
+          "ccid": "715q21g",
+          "accessibilityTags": [
+            "ad",
+            "s"
+          ],
+          "audioDescribed": true,
+          "availabilityFeatures": [
+            "MPEG_DASH",
+            "OUTBAND_WEBVTT",
+            "PLAYREADY",
+            "WIDEVINE",
+            "INBAND_AUDIO_DESCRIPTION"
+          ],
+          "availabilityFrom": "2025-05-18T06:00:00Z",
+          "availabilityUntil": "2030-05-17T22:59:00Z",
+          "genres": [
+            {
+              "id": "DRAMA_AND_SOAPS",
+              "name": "Drama"
+            }
+          ],
+          "channel": "ITV",
+          "fullSeriesRange": [],
+          "heroCtaLabel": "Series 1, Episode 3",
+          "contentInfo": "S1:E3",
+          "contentOwner": null,
+          "dateTime": "2025-05-25T20:00:00.000Z",
+          "description": "Alison's risky tactics identify the gang's target.",
+          "duration": "1h",
+          "episode": 3,
+          "episodeId": "10/5340/0003",
+          "encodedEpisodeId": {
+            "letterA": "10a5340a0003",
+            "underscore": "10_5340_0003"
+          },
+          "episodeTitle": null,
+          "guidance": "with some strong language and violence",
+          "image": "https://ovp.itv.com/v2/images/episode/715q21g/itv_hub/08_Episodic/16x9?distributionPartner=itv_hub&fallback=standard&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+          "linearContent": true,
+          "longDescription": "Alison's risky tactics identify the gang's target, but her deception and the gang's escalating violence threaten to unravel her relationship with Liam.",
+          "longRunning": false,
+          "nextProductionId": "10/5340/0004",
+          "notFormattedDuration": "PT1H",
+          "partnership": null,
+          "playlistUrl": "https://magni.itv.com/playlist/itvonline/ITV/10_5340_0003.001",
+          "premium": false,
+          "productionId": "10/5340/0003#001",
+          "productionType": "EPISODE",
+          "productionYear": null,
+          "programmeId": "10/5340",
+          "series": 1,
+          "subtitled": true,
+          "tier": [
+            "FREE"
+          ],
+          "visuallySigned": false,
+          "regionalisation": true,
+          "broadcastDateTime": "2025-05-25T20:00:00Z",
+          "attribution": {
+            "partnership": null,
+            "contentOwner": null
+          }
+        },
+        {
+          "ccid": "0qdkb2s",
+          "accessibilityTags": [
+            "ad",
+            "s"
+          ],
+          "audioDescribed": true,
+          "availabilityFeatures": [
+            "MPEG_DASH",
+            "OUTBAND_WEBVTT",
+            "PLAYREADY",
+            "WIDEVINE",
+            "INBAND_AUDIO_DESCRIPTION"
+          ],
+          "availabilityFrom": "2025-05-18T06:00:00Z",
+          "availabilityUntil": "2030-05-17T22:59:00Z",
+          "genres": [
+            {
+              "id": "DRAMA_AND_SOAPS",
+              "name": "Drama"
+            }
+          ],
+          "channel": "ITV",
+          "fullSeriesRange": [],
+          "heroCtaLabel": "Series 1, Episode 4",
+          "contentInfo": "S1:E4",
+          "contentOwner": null,
+          "dateTime": "2025-05-26T20:00:00.000Z",
+          "description": "Alison joins Liam on a luxury trip where she scrabbles for clues.",
+          "duration": "1h",
+          "episode": 4,
+          "episodeId": "10/5340/0004",
+          "encodedEpisodeId": {
+            "letterA": "10a5340a0004",
+            "underscore": "10_5340_0004"
+          },
+          "episodeTitle": "Episode 4",
+          "guidance": "with some strong language and violence",
+          "image": "https://ovp.itv.com/v2/images/episode/0qdkb2s/itv_hub/08_Episodic/16x9?distributionPartner=itv_hub&fallback=standard&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+          "linearContent": true,
+          "longDescription": "Alison joins Liam on a luxury trip where she scrabbles for clues about his plans while torn between her growing feelings for him and the police's doubts.",
+          "longRunning": false,
+          "nextProductionId": "10/5340/0005",
+          "notFormattedDuration": "PT1H",
+          "partnership": null,
+          "playlistUrl": "https://magni.itv.com/playlist/itvonline/ITV/10_5340_0004.001",
+          "premium": false,
+          "productionId": "10/5340/0004#001",
+          "productionType": "EPISODE",
+          "productionYear": null,
+          "programmeId": "10/5340",
+          "series": 1,
+          "subtitled": true,
+          "tier": [
+            "FREE"
+          ],
+          "visuallySigned": false,
+          "regionalisation": true,
+          "broadcastDateTime": "2025-05-26T20:00:00Z",
+          "attribution": {
+            "partnership": null,
+            "contentOwner": null
+          }
+        },
+        {
+          "ccid": "wqtmrcs",
+          "accessibilityTags": [
+            "ad",
+            "s"
+          ],
+          "audioDescribed": true,
+          "availabilityFeatures": [
+            "MPEG_DASH",
+            "OUTBAND_WEBVTT",
+            "PLAYREADY",
+            "WIDEVINE",
+            "INBAND_AUDIO_DESCRIPTION"
+          ],
+          "availabilityFrom": "2025-05-18T06:00:00Z",
+          "availabilityUntil": "2030-05-17T22:59:00Z",
+          "genres": [
+            {
+              "id": "DRAMA_AND_SOAPS",
+              "name": "Drama"
+            }
+          ],
+          "channel": "ITV",
+          "fullSeriesRange": [],
+          "heroCtaLabel": "Series 1, Episode 5",
+          "contentInfo": "S1:E5",
+          "contentOwner": null,
+          "dateTime": "2025-06-01T20:00:00.000Z",
+          "description": "Alison discovers Liam's betrayal and races to stop the heist.",
+          "duration": "1h",
+          "episode": 5,
+          "episodeId": "10/5340/0005",
+          "encodedEpisodeId": {
+            "letterA": "10a5340a0005",
+            "underscore": "10_5340_0005"
+          },
+          "episodeTitle": null,
+          "guidance": "with some strong language and violence",
+          "image": "https://ovp.itv.com/v2/images/episode/wqtmrcs/itv_hub/08_Episodic/16x9?distributionPartner=itv_hub&fallback=standard&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+          "linearContent": true,
+          "longDescription": "Alison discovers Liam's betrayal and races to stop the gang's heist - chaos erupts as lives are endangered and Alison is forced to confront the fallout.",
+          "longRunning": false,
+          "nextProductionId": "10/5340/0006",
+          "notFormattedDuration": "PT1H",
+          "partnership": null,
+          "playlistUrl": "https://magni.itv.com/playlist/itvonline/ITV/10_5340_0005.004",
+          "premium": false,
+          "productionId": "10/5340/0005#004",
+          "productionType": "EPISODE",
+          "productionYear": null,
+          "programmeId": "10/5340",
+          "series": 1,
+          "subtitled": true,
+          "tier": [
+            "FREE"
+          ],
+          "visuallySigned": false,
+          "regionalisation": true,
+          "broadcastDateTime": "2025-06-01T20:00:00Z",
+          "attribution": {
+            "partnership": null,
+            "contentOwner": null
+          }
+        },
+        {
+          "ccid": "6m90hrk",
+          "accessibilityTags": [
+            "ad",
+            "s"
+          ],
+          "audioDescribed": true,
+          "availabilityFeatures": [
+            "MPEG_DASH",
+            "OUTBAND_WEBVTT",
+            "PLAYREADY",
+            "WIDEVINE",
+            "INBAND_AUDIO_DESCRIPTION"
+          ],
+          "availabilityFrom": "2025-05-18T06:00:00Z",
+          "availabilityUntil": "2030-05-17T22:59:00Z",
+          "genres": [
+            {
+              "id": "DRAMA_AND_SOAPS",
+              "name": "Drama"
+            }
+          ],
+          "channel": "ITV",
+          "fullSeriesRange": [],
+          "heroCtaLabel": "Series 1, Episode 6",
+          "contentInfo": "S1:E6",
+          "contentOwner": null,
+          "dateTime": "2025-06-02T20:00:00.000Z",
+          "description": "Alison is reeling when her life is suddenly threatened.",
+          "duration": "1h",
+          "episode": 6,
+          "episodeId": "10/5340/0006",
+          "encodedEpisodeId": {
+            "letterA": "10a5340a0006",
+            "underscore": "10_5340_0006"
+          },
+          "episodeTitle": null,
+          "guidance": "with some strong language and violence",
+          "image": "https://ovp.itv.com/v2/images/episode/6m90hrk/itv_hub/08_Episodic/16x9?distributionPartner=itv_hub&fallback=standard&w={width}&h={height}&q={quality}&blur={blur}&bg={bg}",
+          "linearContent": true,
+          "longDescription": "Alison is reeling from Liam's betrayal and consumed with guilt over her role in the heist when her life is suddenly threatened by one of the gang.",
+          "longRunning": false,
+          "notFormattedDuration": "PT1H",
+          "partnership": null,
+          "playlistUrl": "https://magni.itv.com/playlist/itvonline/ITV/10_5340_0006.001",
+          "premium": false,
+          "productionId": "10/5340/0006#001",
+          "productionType": "EPISODE",
+          "productionYear": null,
+          "programmeId": "10/5340",
+          "series": 1,
+          "subtitled": true,
+          "tier": [
+            "FREE"
+          ],
+          "visuallySigned": false,
+          "regionalisation": true,
+          "broadcastDateTime": "2025-06-02T20:00:00Z",
+          "attribution": {
+            "partnership": null,
+            "contentOwner": null
+          }
+        }
+      ]
+    }
+  ],
+  "initialSelectedSeries": "1"
+}

--- a/test/web/test_itv_gql.py
+++ b/test/web/test_itv_gql.py
@@ -19,9 +19,10 @@ from support.object_checks import is_url
 class GetPlaylistUrl(TestCase):
     def test_get_vod_playlist_url(self):
         ccid = 'hcnxs56'  # an episode of 'a spy among friends', has BSL and AD
-        playlist_url = itv_gql.get_playlist_url(ccid)
+        playlist_url, has_ad = itv_gql.get_playlist_url(ccid)
         self.assertTrue(is_url(playlist_url))
-        bsl_playlist_url = itv_gql.get_playlist_url(ccid, prefer_bsl=True)
+        self.assertTrue(has_ad)
+        bsl_playlist_url, has_ad = itv_gql.get_playlist_url(ccid, prefer_bsl=True)
         self.assertTrue(is_url(bsl_playlist_url))
         self.assertNotEqual(playlist_url, bsl_playlist_url)
 

--- a/test/web/test_itvx_html.py
+++ b/test/web/test_itvx_html.py
@@ -713,7 +713,8 @@ class WatchPages(unittest.TestCase):
                 'https://www.itv.com/watch/bad-girls/7a0129',
                 'https://www.itv.com/watch/midsomer-murders/Ya1096',
                 'https://www.itv.com/watch/stonehouse/10a1973',         # programme with BSL
-                'https://www.itv.com/watch/the-chase/1a7842/',          # Some episode do not have a title
+                'https://www.itv.com/watch/the-chase/1a7842/',          # Some episode do not have a title            # programme with BSL and AD
+                'https://www.itv.com/watch/code-of-silence/10a5340',    # programme with AD
                 ):
             page = fetch.get_document(url)
             # testutils.save_doc(page, 'html/series_miss-marple.html')


### PR DESCRIPTION
Enable additional audio channel with audio description whenever available.

AD is availalbe as an secondary audio channel on some VOD programmes. User who prefer AD will have to switch audio channels in Kodi's audio selection dialog while the video plays full screen, or configure a dedicated remote button to toggle through audio channels.